### PR TITLE
Email Required, Retention Correctly Calculated, Tests Fixed

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1334,3 +1334,183 @@ monkeypatch, sample_session):
     payload = _json.loads(first.split("data: ", 1)[1].strip())
     assert any(g["name"] == "Catan" for g in payload["game_tally"])
     assert payload["confirmations"].get("Host") == "yes"
+
+# ── _ensure_game_election_schema: conn.commit() after successful ALTER ────────
+
+def test_ensure_schema_commit_branch(client, app):
+    """Schema function executes conn.commit() on a fresh in-memory DB with no columns yet."""
+    with app.app_context():
+        # Drop the columns that _ensure_game_election_schema tries to add
+        # by dropping and recreating tables without them — easiest way is
+        # just calling the route which triggers the function on a clean DB
+        db.drop_all()
+        db.create_all()
+
+    res = client.post("/create", data={
+        "title": "Schema Commit Test",
+        "name": "Tester",
+        "email": "t@t.com",
+        "is_public": "on",
+    }, follow_redirects=True)
+    assert res.status_code == 200
+
+
+# ── _notify_and_flash: flash success and failure messages ────────────────────
+
+def test_notify_and_flash_flashes_success(monkeypatch, client, app, sample_session):
+    """_notify_and_flash should flash success message when emails are sent."""
+    monkeypatch.setattr("website.views.notify_final_time", lambda s: (3, []))
+    with client.application.test_request_context():
+        from flask import get_flashed_messages
+        from website.views import _notify_and_flash
+        with app.app_context():
+            s = db.session.get(Session, sample_session["session_id"])
+            _notify_and_flash(s)
+
+
+def test_notify_and_flash_flashes_failure(monkeypatch, client, app, sample_session):
+    """_notify_and_flash should flash danger message on email failure."""
+    monkeypatch.setattr(
+        "website.views.notify_final_time",
+        lambda s: (0, [("Bob", "SMTP error")])
+    )
+    with client.application.test_request_context():
+        from website.views import _notify_and_flash
+        with app.app_context():
+            s = db.session.get(Session, sample_session["session_id"])
+            _notify_and_flash(s)
+
+
+# ── join_and_vote: host_id assigned when session has no host ─────────────────
+
+def test_join_and_vote_assigns_host_when_none(client, app):
+    """join_and_vote should set host_id when session has no host."""
+    with app.app_context():
+        s = Session(title="No Host", is_public=True)
+        db.session.add(s)
+        db.session.commit()
+        session_hash = s.hash_id
+        session_id = s.id
+
+    res = client.post(
+        f"/session/{session_hash}/join_and_vote",
+        data={"name": "First", "email": "first@test.com", "game_name": "Chess"},
+        follow_redirects=True
+    )
+    assert res.status_code == 200
+
+    with app.app_context():
+        updated = db.session.get(Session, session_id)
+        assert updated.host_id is not None
+
+
+# ── remove_availability: non-XHR failure path flashes and redirects ──────────
+
+def test_remove_availability_non_xhr_not_found(client, sample_session):
+    """Non-XHR remove of missing block should flash warning and redirect."""
+    res = client.post(
+        f"/session/{sample_session['session_hash']}/remove_availability",
+        data={
+            "token": sample_session["host_token"],
+            "start": datetime.now().isoformat(),
+            "end": (datetime.now() + timedelta(hours=1)).isoformat()
+        }
+    )
+    assert res.status_code == 302
+
+
+def test_remove_availability_non_xhr_missing_fields(client, sample_session):
+    """Non-XHR remove with missing fields should flash warning and redirect."""
+    res = client.post(
+        f"/session/{sample_session['session_hash']}/remove_availability",
+        data={"token": sample_session["host_token"]}
+    )
+    assert res.status_code == 302
+
+
+def test_remove_availability_non_xhr_invalid_time(client, sample_session):
+    """Non-XHR remove with invalid time should flash warning and redirect."""
+    res = client.post(
+        f"/session/{sample_session['session_hash']}/remove_availability",
+        data={
+            "token": sample_session["host_token"],
+            "start": "bad",
+            "end": "bad"
+        }
+    )
+    assert res.status_code == 302
+
+
+# ── _sse_generate: gone, reconnect, keepalive last_keepalive=now branch ──────
+
+def test_sse_generate_keepalive_updates_last_keepalive(app, monkeypatch, sample_session):
+    """After a keepalive, last_keepalive should reset so next keepalive is delayed."""
+    import website.views as vmod
+
+    # time sequence: start=0, loop1 check=0 (state), now=16 (keepalive fires),
+    # last_keepalive becomes 16; loop2 now=17 (< 16+15=31, no second keepalive),
+    # then 400 to expire
+    times = iter([0.0, 0.0, 16.0, 16.0, 17.0, 17.0, 400.0])
+    fake_t = __import__("types").SimpleNamespace(
+        time=lambda: next(times), sleep=lambda _: None
+    )
+    monkeypatch.setattr(vmod, "_time", fake_t)
+    monkeypatch.setattr(vmod, "_SSE_KEEPALIVE_EVERY", 15)
+    monkeypatch.setattr(vmod, "_SSE_MAX_DURATION", 300)
+
+    with app.app_context():
+        gen = _sse_generate(sample_session["session_hash"])
+        first = next(gen)
+        assert first.startswith("event: state\n")
+        second = next(gen)
+        assert second == ": keepalive\n\n"
+        # Third event: time=400 triggers reconnect, NOT a second keepalive
+        third = next(gen)
+        assert third == "event: reconnect\ndata: {}\n\n"
+
+
+# ── seed_test_data route ──────────────────────────────────────────────────────
+
+def test_seed_test_data_route(client):
+    """POST /seed-test-data should seed data and redirect to dashboard."""
+    res = client.post("/seed-test-data", follow_redirects=True)
+    assert res.status_code == 200
+
+
+def test_seed_test_data_creates_expected_users(client, app):
+    """Seeding should create 6 unique participants across multiple sessions."""
+    client.post("/seed-test-data")
+    with app.app_context():
+        all_participants = Participant.query.all()
+        unique_emails = {
+            (p.email or "").strip().lower()
+            for p in all_participants
+            if (p.email or "").strip()
+        }
+        assert len(unique_emails) == 6
+
+
+def test_seed_test_data_creates_sessions(client, app):
+    """Seeding should create 6 sessions."""
+    client.post("/seed-test-data")
+    with app.app_context():
+        assert Session.query.count() == 6
+
+
+def test_seed_test_data_alice_has_two_sessions(client, app):
+    """Alice should have participant rows in 2 different sessions."""
+    client.post("/seed-test-data")
+    with app.app_context():
+        alice_rows = Participant.query.filter_by(email="alice@test.com").all()
+        assert len(alice_rows) == 2
+
+
+def test_seed_test_data_eve_has_confirmation(client, app):
+    """Eve should have a confirmation after seeding."""
+    client.post("/seed-test-data")
+    with app.app_context():
+        eve = Participant.query.filter_by(email="eve@test.com").first()
+        assert eve is not None
+        conf = Confirmation.query.filter_by(participant_id=eve.id).first()
+        assert conf is not None
+        assert conf.status == "yes"

--- a/website/metrics.py
+++ b/website/metrics.py
@@ -84,46 +84,43 @@ def _collect_activation_rate(unique_joined):
 def _collect_repeat_usage(all_participants, unique_joined):
     """Return repeat usage rate as a rounded float."""
     repeat_count = 0
-    seen_keys = set()
 
+    # Group all participant IDs by email (one user = one email)
+    email_to_ids = {}
     for p in all_participants:
-        key = (p.email or "").strip().lower()
-        if not key or key in seen_keys:
-            continue
-        seen_keys.add(key)
+        key = (p.email or "").strip().lower() or f"id:{p.id}"
+        email_to_ids.setdefault(key, []).append(p.id)
 
+    for key, pids in email_to_ids.items():
         events = []
 
-        # Hosting sessions
-        for s in Session.query.filter_by(host_id=p.id).all():
-            if s.datetime:
-                t = s.datetime.replace(tzinfo=timezone.utc) if s.datetime.tzinfo is None else s.datetime
-                events.append((t, s.id, 'host'))
+        for pid in pids:
+            # Hosting sessions — check all participant IDs for this email
+            for s in Session.query.filter_by(host_id=pid).all():
+                if s.datetime:
+                    t = s.datetime.replace(tzinfo=timezone.utc) if s.datetime.tzinfo is None else s.datetime
+                    events.append((t, s.id, 'host'))
 
-        # Confirmations (created or updated)
-        for c in Confirmation.query.filter_by(participant_id=p.id).all():
-            for t_attr in ['created_at', 'updated_at']:
-                t = getattr(c, t_attr, None)
-                if t:
-                    t = t.replace(tzinfo=timezone.utc) if t.tzinfo is None else t
-                    events.append((t, c.session_id, t_attr))
+            # Confirmations
+            for c in Confirmation.query.filter_by(participant_id=pid).all():
+                for t_attr in ['created_at', 'updated_at']:
+                    t = getattr(c, t_attr, None)
+                    if t:
+                        t = t.replace(tzinfo=timezone.utc) if t.tzinfo is None else t
+                        events.append((t, c.session_id, t_attr))
 
-        # Sort by timestamp
         events.sort(key=lambda x: x[0])
 
-        # Track if any repeat activity exists
         for i in range(1, len(events)):
             prev = events[i - 1]
             curr = events[i]
 
-            # Ignore if both activities are for same session and same timestamp
             if prev[1] == curr[1] and prev[0] == curr[0]:
                 continue
 
-            # Count as repeat if within window
-            if (curr[0] - prev[0]) <= timedelta(days=7):
+            if timedelta(days=1) <= (curr[0] - prev[0]) <= timedelta(days=7):
                 repeat_count += 1
-                break  # Count each participant only once
+                break
 
     return round(repeat_count / unique_joined * 100, 1) if unique_joined else 0
 

--- a/website/templates/dashboard.html
+++ b/website/templates/dashboard.html
@@ -130,5 +130,9 @@
       <button type="submit" class="btn btn-outline-danger">Reset database</button>
     </form>
   </div>
+  
+  <form method="POST" action="/seed-test-data">
+    <button class="btn btn-outline-primary btn-sm">Seed Test Data</button>
+  </form>
 </div>
 {% endblock %}

--- a/website/utils.py
+++ b/website/utils.py
@@ -47,3 +47,40 @@ def notify_final_time(session):
             failed.append((participant.name, str(e)))
 
     return sent_count, failed
+
+def notify_personal_link(participant, session):
+    """Send a personal link email to a participant when they join or create a session."""
+    if not (
+        current_app.config.get("MAIL_USERNAME")
+        and current_app.config.get("MAIL_PASSWORD")
+    ):
+        return False, None
+
+    if not (participant.email and participant.email.strip()):
+        return False, None
+
+    session_url = url_for(
+        "main.view_session",
+        session_hash=session.hash_id,
+        token=participant.token,
+        _external=True,
+    )
+
+    msg = Message(
+        subject=f"Your personal link for {session.title}",
+        recipients=[participant.email.strip()],
+        body=(
+            f"Hi {participant.name},\n\n"
+            f"Here is your personal link for '{session.title}'.\n"
+            f"Use it to view the session, update your availability, and confirm your attendance:\n\n"
+            f"{session_url}\n\n"
+            f"Save this link — it's the only way to access your session without logging in.\n\n"
+            f"Thanks!"
+        ),
+    )
+
+    try:
+        mail.send(msg)
+        return True, None
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        return False, str(e)

--- a/website/views.py
+++ b/website/views.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from website import db
 from website.models import Confirmation, Participant, Session, Availability, GameVote
-from website.utils import notify_final_time
+from website.utils import notify_final_time, notify_personal_link
 
 main = Blueprint("main", __name__)
 
@@ -129,6 +129,7 @@ def create_session():
         )
         db.session.add(host_participant)
         db.session.commit()
+        notify_personal_link(host_participant, new_session)
 
         new_session.host_id = host_participant.id
         db.session.commit()
@@ -156,6 +157,8 @@ def join_session(session_id):
     if not game_session.host_id:
         game_session.host_id = participant.id
         db.session.commit()
+
+    notify_personal_link(participant, game_session)
 
     return redirect(url_for(
         "main.view_session",
@@ -858,3 +861,83 @@ def stream_session(session_hash):
             "Connection": "keep-alive",
         },
     )
+
+@main.route("/seed-test-data", methods=["POST"])
+def seed_test_data():
+    """Seed fake participants and sessions for metrics testing."""
+    from datetime import datetime, timezone, timedelta
+    from website.models import Participant, Session, Confirmation, Availability
+
+    now = datetime.now(timezone.utc)
+
+    # ── User A: repeat user (2 sessions, 3 days apart) ──────────────────
+    s1 = Session(title="User A Session 1", is_public=True, datetime=now - timedelta(days=6))
+    s2 = Session(title="User A Session 2", is_public=True, datetime=now - timedelta(days=3))
+    db.session.add_all([s1, s2])
+    db.session.commit()
+
+    a1 = Participant(name="Alice", email="alice@test.com", session_id=s1.id)
+    db.session.add(a1)
+    db.session.commit()
+    s1.host_id = a1.id
+
+    a2 = Participant(name="Alice", email="alice@test.com", session_id=s2.id)
+    db.session.add(a2)
+    db.session.commit()
+    s2.host_id = a2.id
+
+    # ── User B: same-day activity only (should NOT count as repeat) ──────
+    s3 = Session(title="User B Session", is_public=True, datetime=now - timedelta(hours=2))
+    db.session.add(s3)
+    db.session.commit()
+
+    b1 = Participant(name="Bob", email="bob@test.com", session_id=s3.id)
+    db.session.add(b1)
+    db.session.commit()
+    s3.host_id = b1.id
+
+    c1 = Confirmation(participant_id=b1.id, session_id=s3.id, status="yes",
+                      created_at=now - timedelta(hours=1))
+    db.session.add(c1)
+
+    # ── User C: activity 10 days apart (outside 7-day window, NOT repeat) 
+    s4 = Session(title="User C Session 1", is_public=True, datetime=now - timedelta(days=12))
+    s5 = Session(title="User C Session 2", is_public=True, datetime=now - timedelta(days=2))
+    db.session.add_all([s4, s5])
+    db.session.commit()
+
+    c_p1 = Participant(name="Carol", email="carol@test.com", session_id=s4.id)
+    db.session.add(c_p1)
+    db.session.commit()
+    s4.host_id = c_p1.id
+
+    c_p2 = Participant(name="Carol", email="carol@test.com", session_id=s5.id)
+    db.session.add(c_p2)
+    db.session.commit()
+    s5.host_id = c_p2.id
+
+    # ── User D: joined but no activity (not activated) ───────────────────
+    s6 = Session(title="Host Session", is_public=True, datetime=now)
+    db.session.add(s6)
+    db.session.commit()
+
+    host = Participant(name="Host", email="host@test.com", session_id=s6.id)
+    db.session.add(host)
+    db.session.commit()
+    s6.host_id = host.id
+
+    d1 = Participant(name="Dave", email="dave@test.com", session_id=s6.id)
+    db.session.add(d1)
+
+    # ── User E: confirmed (activated, not repeat) ─────────────────────────
+    e1 = Participant(name="Eve", email="eve@test.com", session_id=s6.id)
+    db.session.add(e1)
+    db.session.commit()
+
+    conf_e = Confirmation(participant_id=e1.id, session_id=s6.id, status="yes",
+                          created_at=now - timedelta(days=1))
+    db.session.add(conf_e)
+
+    db.session.commit()
+    flash("Test data seeded.", "success")
+    return redirect(url_for("main.dashboard"))


### PR DESCRIPTION
## Personal Link Email on Join/Create & Retention Metric Fixes

### Summary
Two improvements in this PR: automatically emailing participants their personal session link on join/create (since there is no auth), and fixing the repeat usage metric to correctly deduplicate users by email across multiple sessions.

---

### Changes

**utils.py**
- Added `notify_personal_link(participant, session)` — sends a personal session link email to a participant on join/create
- Follows the same pattern as `notify_final_time`: silently no-ops if `MAIL_USERNAME`/`MAIL_PASSWORD` are not configured, or if the participant has no email
- Email body explicitly instructs the user to save their link since there is no login system

**views.py**
- Added `notify_personal_link` to the `from website.utils import ...` line
- Called `notify_personal_link` in `create_session` after the host participant is committed
- Called `notify_personal_link` in `join_session` after `game_session` is assigned and committed — fixing an `UnboundLocalError` caused by calling it before the variable was in scope

**metrics.py**
- Fixed `_collect_repeat_usage` to group all participant IDs by email before collecting events — previously, the same person creating multiple sessions would produce multiple participant rows, and only the first row's events were checked
- Repeat usage window tightened to `1 day ≤ gap ≤ 7 days` — previously any gap ≤ 7 days counted, meaning two events in the same session minutes apart would incorrectly count as repeat usage
- Fallback key `id:{p.id}` used for participants with no email, consistent with the rest of `metrics.py`

---

### Why

**Personal link email**: Without auth, the personal link is the only way back into a session. Losing it means a participant can no longer update availability or confirm attendance.

**Retention fix**: Because each session creates a new `Participant` row even for the same person, the old logic only saw one row's events per email. A host creating two sessions would never register as a repeat user. The new logic collects all participant IDs for a given email first, then builds a unified event timeline.

---

### Testing
- Reset DB → Seed Test Data → dashboard should show: 6 unique users, 6 sessions, 16.7% repeat usage, 83.3% activation rate
- Configure `MAIL_USERNAME`/`MAIL_PASSWORD` and create/join a session — participant should receive a personal link email
- Without mail config, join/create works normally with no errors
- All existing tests pass