### PR TITLE
Update Disclosure & Dashboard

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,6 +9,7 @@ Unit tests for website/metrics.py
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 
 from website import create_app, db
 from website.models import Session, Participant, Availability, Confirmation
@@ -124,6 +125,12 @@ def test_calculate_metrics_no_data(app):
     assert metrics["confirmed_participants"] == 0
     assert metrics["activation_rate"] == "0%"
     assert metrics["repeat_usage"] == "0%"
+    assert metrics["multi_participant_rate"] == "0%"
+    assert metrics["completion_rate"] == "0%"
+    assert metrics["avg_participants"] == 0
+    assert metrics["sessions_with_votes_pct"] == "0%"
+    assert metrics["top_games"] == []
+    assert metrics["confirmation_breakdown"] == {"Yes": 0, "Maybe": 0, "No": 0}
 
 
 def test_calculate_metrics_availability_and_confirmation(app):
@@ -335,3 +342,36 @@ def test_calculate_metrics_participant_query_fails(monkeypatch, app):
 
     assert metrics["total_users"] == 0
     assert metrics["sessions_created"] == 0
+    
+def _raiser(*a, **kw):
+    raise SQLAlchemyError("fail")
+
+def test_multi_participant_rate_db_error(monkeypatch, app):
+    monkeypatch.setattr("website.metrics._sessions_with_multiple_participants", _raiser)
+    with app.app_context():
+        assert calculate_metrics()["multi_participant_rate"] == "0%"
+
+def test_completion_rate_db_error(monkeypatch, app):
+    monkeypatch.setattr("website.metrics._session_completion_rate", _raiser)
+    with app.app_context():
+        assert calculate_metrics()["completion_rate"] == "0%"
+
+def test_avg_participants_db_error(monkeypatch, app):
+    monkeypatch.setattr("website.metrics._avg_participants_per_session", _raiser)
+    with app.app_context():
+        assert calculate_metrics()["avg_participants"] == 0
+
+def test_sessions_with_votes_db_error(monkeypatch, app):
+    monkeypatch.setattr("website.metrics._sessions_with_votes", _raiser)
+    with app.app_context():
+        assert calculate_metrics()["sessions_with_votes_pct"] == "0%"
+
+def test_top_games_db_error(monkeypatch, app):
+    monkeypatch.setattr("website.metrics._top_games", _raiser)
+    with app.app_context():
+        assert calculate_metrics()["top_games"] == []
+
+def test_confirmation_breakdown_db_error(monkeypatch, app):
+    monkeypatch.setattr("website.metrics._confirmation_breakdown", _raiser)
+    with app.app_context():
+        assert calculate_metrics()["confirmation_breakdown"] == {"Yes": 0, "Maybe": 0, "No": 0}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -73,7 +73,21 @@ def test_index(client):
 
 def test_dashboard(client, monkeypatch):
     """Dashboard should render with mocked metrics."""
-    monkeypatch.setattr("website.metrics.calculate_metrics", lambda: {"sessions": 1})
+    monkeypatch.setattr("website.metrics.calculate_metrics", lambda: {
+        "total_users": 0,
+        "sessions_created": 0,
+        "confirmed_participants": 0,
+        "availability_only_participants": 0,
+        "activation_rate": "0%",
+        "repeat_usage": "0%",
+        "unique_emails": [],
+        "multi_participant_rate": "0%",
+        "completion_rate": "0%",
+        "avg_participants": 0,
+        "sessions_with_votes_pct": "0%",
+        "top_games": [],
+        "confirmation_breakdown": {"Yes": 0, "Maybe": 0, "No": 0},
+    })
     res = client.get("/dashboard")
     assert res.status_code == 200
 

--- a/website/metrics.py
+++ b/website/metrics.py
@@ -4,12 +4,13 @@ metrics.py
 Calculates usage metrics for the SynQ dashboard.
 """
 
+from collections import Counter
 from datetime import timezone, timedelta
 
 from sqlalchemy.exc import SQLAlchemyError
 
 from website import db
-from website.models import Participant, Session, Availability, Confirmation
+from website.models import Participant, Session, Availability, Confirmation, GameVote
 
 
 def _unique_key(p):
@@ -18,10 +19,6 @@ def _unique_key(p):
 
 
 def _collect_confirmed_keys():
-    """
-    Return set of unique participant keys who have a confirmation.
-    Only participants with a confirmation count as 'confirmed'.
-    """
     confirmed_keys = set()
     confirmed_participant_ids = {
         r[0] for r in db.session.query(Confirmation.participant_id).distinct().all()
@@ -33,11 +30,8 @@ def _collect_confirmed_keys():
             confirmed_keys.add(_unique_key(p))
     return confirmed_keys
 
+
 def _collect_availability_keys():
-    """
-    Return set of unique participant keys who have submitted availability,
-    but may not have confirmed yet.
-    """
     availability_keys = set()
     participant_ids = {
         r[0] for r in db.session.query(Availability.participant_id).distinct().all()
@@ -49,15 +43,10 @@ def _collect_availability_keys():
             availability_keys.add(_unique_key(p))
     return availability_keys
 
+
 def _collect_activated_keys():
-    """
-    Return set of unique participant keys who have activity:
-    - Hosted a session
-    - Created or updated a confirmation
-    """
     activated_keys = set()
 
-    # Participants who hosted sessions
     hosts = {
         r[0] for r in Session.query.with_entities(Session.host_id).distinct().all()
         if r[0] is not None
@@ -67,7 +56,6 @@ def _collect_activated_keys():
         if p:
             activated_keys.add(_unique_key(p))
 
-    # Participants who confirmed (created or updated)
     confirmations = Confirmation.query.all()
     for c in confirmations:
         p = db.session.get(Participant, c.participant_id)
@@ -76,16 +64,15 @@ def _collect_activated_keys():
 
     return activated_keys
 
+
 def _collect_activation_rate(unique_joined):
-    """Return activation rate as a percentage based on actual activity."""
     activated_keys = _collect_activated_keys()
     return round(len(activated_keys) / unique_joined * 100, 1) if unique_joined else 0
 
+
 def _collect_repeat_usage(all_participants, unique_joined):
-    """Return repeat usage rate as a rounded float."""
     repeat_count = 0
 
-    # Group all participant IDs by email (one user = one email)
     email_to_ids = {}
     for p in all_participants:
         key = (p.email or "").strip().lower() or f"id:{p.id}"
@@ -95,13 +82,11 @@ def _collect_repeat_usage(all_participants, unique_joined):
         events = []
 
         for pid in pids:
-            # Hosting sessions — check all participant IDs for this email
             for s in Session.query.filter_by(host_id=pid).all():
                 if s.datetime:
                     t = s.datetime.replace(tzinfo=timezone.utc) if s.datetime.tzinfo is None else s.datetime
                     events.append((t, s.id, 'host'))
 
-            # Confirmations
             for c in Confirmation.query.filter_by(participant_id=pid).all():
                 for t_attr in ['created_at', 'updated_at']:
                     t = getattr(c, t_attr, None)
@@ -124,6 +109,63 @@ def _collect_repeat_usage(all_participants, unique_joined):
 
     return round(repeat_count / unique_joined * 100, 1) if unique_joined else 0
 
+
+def _sessions_with_multiple_participants(all_sessions):
+    """% of sessions where participant count > 1."""
+    if not all_sessions:
+        return 0
+    multi = sum(
+        1 for s in all_sessions
+        if Participant.query.filter_by(session_id=s.id).count() > 1
+    )
+    return round(multi / len(all_sessions) * 100, 1)
+
+
+def _session_completion_rate(all_sessions):
+    """% of sessions that have a final_time set."""
+    if not all_sessions:
+        return 0
+    completed = sum(1 for s in all_sessions if s.final_time is not None)
+    return round(completed / len(all_sessions) * 100, 1)
+
+
+def _avg_participants_per_session(all_sessions):
+    """Average number of participants across all sessions."""
+    if not all_sessions:
+        return 0
+    total = sum(Participant.query.filter_by(session_id=s.id).count() for s in all_sessions)
+    return round(total / len(all_sessions), 1)
+
+
+def _sessions_with_votes(all_sessions):
+    """% of sessions that have at least one game vote."""
+    if not all_sessions:
+        return 0
+    with_votes = sum(
+        1 for s in all_sessions
+        if GameVote.query.filter_by(session_id=s.id).count() > 0
+    )
+    return round(with_votes / len(all_sessions) * 100, 1)
+
+
+def _top_games(limit=5):
+    """Return list of (game_name, count) tuples sorted by vote count descending."""
+    votes = GameVote.query.with_entities(GameVote.game_name).all()
+    counts = Counter(v[0] for v in votes if v[0])
+    return counts.most_common(limit)
+
+
+def _confirmation_breakdown():
+    """Return dict of {status: count} for all confirmations."""
+    rows = Confirmation.query.with_entities(Confirmation.status).all()
+    counts = Counter(r[0] for r in rows if r[0])
+    return {
+        "Yes":   counts.get("Yes", 0),
+        "Maybe": counts.get("Maybe", 0),
+        "No":    counts.get("No", 0),
+    }
+
+
 def calculate_metrics():
     """Return dashboard metrics dict."""
     try:
@@ -134,15 +176,21 @@ def calculate_metrics():
         unique_joined = 0
 
     try:
+        all_sessions = Session.query.all()
+        total_sessions = len(all_sessions)
+    except SQLAlchemyError:
+        all_sessions = []
+        total_sessions = 0
+
+    try:
         confirmed_keys = _collect_confirmed_keys()
         confirmed_count = len(confirmed_keys)
     except SQLAlchemyError:
         confirmed_keys = set()
         confirmed_count = 0
-    
+
     try:
         availability_keys = _collect_availability_keys()
-        # Only count users who submitted availability but are NOT confirmed
         availability_only_count = len(availability_keys - confirmed_keys)
     except SQLAlchemyError:
         availability_only_count = 0
@@ -158,11 +206,6 @@ def calculate_metrics():
         repeat_usage = 0
 
     try:
-        total_sessions = Session.query.count()
-    except SQLAlchemyError:
-        total_sessions = 0
-
-    try:
         unique_emails = sorted({
             p.email.strip().lower()
             for p in all_participants
@@ -170,7 +213,37 @@ def calculate_metrics():
         })
     except SQLAlchemyError:
         unique_emails = []
-    
+
+    try:
+        multi_participant_rate = _sessions_with_multiple_participants(all_sessions)
+    except SQLAlchemyError:
+        multi_participant_rate = 0
+
+    try:
+        completion_rate = _session_completion_rate(all_sessions)
+    except SQLAlchemyError:
+        completion_rate = 0
+
+    try:
+        avg_participants = _avg_participants_per_session(all_sessions)
+    except SQLAlchemyError:
+        avg_participants = 0
+
+    try:
+        sessions_with_votes_pct = _sessions_with_votes(all_sessions)
+    except SQLAlchemyError:
+        sessions_with_votes_pct = 0
+
+    try:
+        top_games = _top_games()
+    except SQLAlchemyError:
+        top_games = []
+
+    try:
+        confirmation_breakdown = _confirmation_breakdown()
+    except SQLAlchemyError:
+        confirmation_breakdown = {"Yes": 0, "Maybe": 0, "No": 0}
+
     return {
         "total_users": unique_joined,
         "sessions_created": total_sessions,
@@ -179,4 +252,10 @@ def calculate_metrics():
         "activation_rate": f"{activation_rate}%",
         "repeat_usage": f"{repeat_usage}%",
         "unique_emails": unique_emails,
+        "multi_participant_rate": f"{multi_participant_rate}%",
+        "completion_rate": f"{completion_rate}%",
+        "avg_participants": avg_participants,
+        "sessions_with_votes_pct": f"{sessions_with_votes_pct}%",
+        "top_games": top_games,
+        "confirmation_breakdown": confirmation_breakdown,
     }

--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -564,3 +564,151 @@ hr {
         padding: 8px 4px;
     }
 }
+
+ .dashboard-game {
+    background: linear-gradient(135deg, #0f0c29 0%, #1a0a2e 30%, #16213e 60%, #0f3460 100%);
+    min-height: 80vh;
+    border-radius: 16px;
+    padding: 2rem;
+    position: relative;
+    overflow: hidden;
+  }
+  .dashboard-game::before {
+    content: "";
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background-image: radial-gradient(circle at 20% 80%, rgba(0, 255, 255, 0.06) 0%, transparent 50%),
+                      radial-gradient(circle at 80% 20%, rgba(255, 0, 128, 0.06) 0%, transparent 50%);
+    pointer-events: none;
+  }
+  .dashboard-game .dashboard-title {
+    font-family: 'Segoe UI', system-ui, sans-serif;
+    font-weight: 800;
+    font-size: 1.75rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    background: linear-gradient(90deg, #00ffff, #ff00aa, #00ff88);
+    background-size: 200% auto;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin-bottom: 1.5rem;
+  }
+  .dashboard-game .stat-card {
+    background: rgba(15, 20, 45, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 1.25rem;
+    text-align: center;
+    transition: transform 0.2s, box-shadow 0.2s;
+    position: relative;
+  }
+  .dashboard-game .stat-card:hover {
+    transform: translateY(-4px);
+  }
+  .dashboard-game .stat-card.cyan    { box-shadow: 0 0 20px rgba(0, 255, 255, 0.25);   border-color: rgba(0, 255, 255, 0.4); }
+  .dashboard-game .stat-card.magenta { box-shadow: 0 0 20px rgba(255, 0, 128, 0.25);   border-color: rgba(255, 0, 128, 0.4); }
+  .dashboard-game .stat-card.lime    { box-shadow: 0 0 20px rgba(0, 255, 136, 0.25);   border-color: rgba(0, 255, 136, 0.4); }
+  .dashboard-game .stat-card.orange  { box-shadow: 0 0 20px rgba(255, 165, 0, 0.25);   border-color: rgba(255, 165, 0, 0.4); }
+  .dashboard-game .stat-card.purple  { box-shadow: 0 0 20px rgba(168, 85, 247, 0.25);  border-color: rgba(168, 85, 247, 0.4); }
+  .dashboard-game .stat-card.teal    { box-shadow: 0 0 20px rgba(0, 210, 180, 0.25);   border-color: rgba(0, 210, 180, 0.4); }
+  .dashboard-game .stat-card.blue    { box-shadow: 0 0 20px rgba(56, 138, 221, 0.25);  border-color: rgba(56, 138, 221, 0.4); }
+  .dashboard-game .stat-card .stat-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
+  }
+  .dashboard-game .stat-card.cyan    .stat-label { color: #00ffff; }
+  .dashboard-game .stat-card.magenta .stat-label { color: #ff00aa; }
+  .dashboard-game .stat-card.lime    .stat-label { color: #00ff88; }
+  .dashboard-game .stat-card.orange  .stat-label { color: #ffa500; }
+  .dashboard-game .stat-card.purple  .stat-label { color: #a855f7; }
+  .dashboard-game .stat-card.teal    .stat-label { color: #00d2b4; }
+  .dashboard-game .stat-card.blue    .stat-label { color: #388add; }
+  .dashboard-game .stat-card .stat-value {
+    font-size: 2rem;
+    font-weight: 800;
+    color: #fff;
+    text-shadow: 0 0 20px rgba(255, 255, 255, 0.3);
+  }
+  .dashboard-game .stat-card .stat-hint {
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.5);
+    margin-top: 0.35rem;
+  }
+
+  /* Game bar chart */
+  .game-bar-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 0.6rem;
+  }
+  .game-bar-label {
+    font-size: 0.78rem;
+    color: rgba(255,255,255,0.8);
+    min-width: 140px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: left;
+  }
+  .game-bar-track {
+    flex: 1;
+    height: 6px;
+    background: rgba(255,255,255,0.1);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+  .game-bar-fill {
+    height: 100%;
+    border-radius: 3px;
+    background: linear-gradient(90deg, #00ffff, #00ff88);
+  }
+  .game-bar-count {
+    font-size: 0.75rem;
+    color: rgba(255,255,255,0.5);
+    min-width: 20px;
+    text-align: right;
+  }
+
+  /* Confirmation breakdown */
+  .confirm-bar-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 0.6rem;
+  }
+  .confirm-bar-label {
+    font-size: 0.78rem;
+    min-width: 50px;
+    text-align: left;
+  }
+  .confirm-bar-track {
+    flex: 1;
+    height: 6px;
+    background: rgba(255,255,255,0.1);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+  .confirm-bar-count {
+    font-size: 0.75rem;
+    color: rgba(255,255,255,0.5);
+    min-width: 20px;
+    text-align: right;
+  }
+
+  .section-divider {
+    border-color: rgba(255,255,255,0.1);
+    margin: 1.5rem 0 1rem;
+  }
+  .section-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(255,255,255,0.3);
+    margin-bottom: 0.75rem;
+  }

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -19,11 +19,33 @@
     setTimeout(function () {
       if (!localStorage.getItem('disclosureSeen')) {
         var modalEl = document.getElementById('policyModal');
-        var modal = new bootstrap.Modal(modalEl);
+        var modal = new bootstrap.Modal(modalEl, { backdrop: 'static', keyboard: false });
         modal.show();
-        localStorage.setItem('disclosureSeen', 'true');
       }
     }, 500);
+ 
+    // Scroll-to-enable logic
+    var modalBody = document.getElementById('policyModalBody');
+    var agreeBtn = document.getElementById('policyAgreeBtn');
+ 
+    if (modalBody && agreeBtn) {
+      modalBody.addEventListener('scroll', function () {
+        var atBottom = modalBody.scrollHeight - modalBody.scrollTop <= modalBody.clientHeight + 10;
+        if (atBottom) {
+          agreeBtn.disabled = false;
+          agreeBtn.classList.remove('disabled');
+        }
+      });
+    }
+ 
+    if (agreeBtn) {
+      agreeBtn.addEventListener('click', function () {
+        localStorage.setItem('disclosureSeen', 'true');
+        var modalEl = document.getElementById('policyModal');
+        var modal = bootstrap.Modal.getInstance(modalEl);
+        modal.hide();
+      });
+    }
   });
 </script>
 
@@ -82,42 +104,85 @@
 <div class="modal fade" id="policyModal" tabindex="-1" aria-labelledby="policyModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg modal-dialog-scrollable">
     <div class="modal-content">
-
+ 
       <div class="modal-header">
         <h5 class="modal-title" id="policyModalLabel">Disclosure & Privacy Policy</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        <!-- No close button — must read and agree -->
       </div>
-
-      <div class="modal-body">
-
+ 
+      <div class="modal-body" id="policyModalBody" style="max-height: 60vh; overflow-y: scroll;">
+ 
         <div class="disclaimer">
-            <p>
-                <strong>Disclosure:</strong> This application is part of a university software engineering course project.
-                It is in an experimental state and is used to improve product ideas. Data collected will be
-                used for educational purposes only. By using this application, you acknowledge that it should
-                not be relied upon for important decisions or critical tasks. The developers and the university
-                assume no liability for any loss, harm, or damages resulting from the use of this prototype.
-            </p>
+          <h6><strong>What is SynQ?</strong></h6>
+          <p>
+            SynQ is a session scheduling tool built as part of a university software engineering course project
+            at Colby College. It helps groups of people find a time that works for everyone and vote on what
+            to play. The app is experimental and actively being developed and improved.
+          </p>
+ 
+          <h6><strong>What data do we collect?</strong></h6>
+          <p>
+            When you create or join a session, we collect:
+          </p>
+          <ul>
+            <li>Your <strong>name</strong> and <strong>email address</strong>, which you provide when joining a session.</li>
+            <li>Your <strong>availability</strong> (the time blocks you submit on the calendar).</li>
+            <li>Your <strong>game votes</strong> and <strong>confirmation responses</strong>.</li>
+            <li>The <strong>date and time</strong> of your interactions with the app.</li>
+          </ul>
+ 
+          <h6><strong>Why do we collect it?</strong></h6>
+          <p>
+            We use your email address to:
+          </p>
+          <ul>
+            <li>Send you a personal link to your session so you can return and update your availability.</li>
+            <li>Notify you when a final session time has been chosen.</li>
+            <li>Measure <strong>retention</strong> — whether users come back to the app after their first session — as part of our course research and product validation.</li>
+          </ul>
+          <p>
+            All data collected is used for <strong>educational and research purposes only</strong>, as part of a
+            software engineering course. We do not sell, share, or use your data for any commercial purpose.
+          </p>
+ 
+          <h6><strong>How long is your data kept?</strong></h6>
+          <p>
+            Data is stored for the duration of the course project. You may request deletion of your data at
+            any time by contacting the development team.
+          </p>
+ 
+          <h6><strong>Disclaimer</strong></h6>
+          <p>
+            This is a prototype application. It should not be relied upon for important decisions or
+            time-sensitive coordination. The developers and Colby College assume no liability for any loss,
+            harm, or inconvenience resulting from its use.
+          </p>
+ 
+          <p class="mt-3" style="font-size: 0.85rem;">
+            By clicking <strong>I Agree</strong>, you acknowledge that you have read and understood this disclosure,
+            and consent to the collection and use of your data as described above.
+          </p>
         </div>
-
-        <div class="privacy-notice mt-3">
-            <p>
-                <strong>Privacy Notice:</strong> This application collects data from users for validating and improving
-                the product. Data collected includes email address as well as user interactions while using the
-                app. This data is used for educational purposes only, and users can request removal of their
-                data at any time.
-            </p>
-        </div>
-
+ 
       </div>
-
-      <div class="modal-footer">
-        <button class="btn btn-primary" data-bs-dismiss="modal">Close</button>
+ 
+      <div class="modal-footer d-flex justify-content-between align-items-center">
+        <small class="text">Scroll to the bottom to continue.</small>
+        <button id="policyAgreeBtn" class="btn btn-primary disabled" disabled>I Agree</button>
       </div>
-
+ 
     </div>
   </div>
 </div>
+
+<!-- Footer trigger (always accessible) -->
+<footer class="footer text-center mt-2">
+  <button class="btn btn-link text-decoration-none"
+          data-bs-toggle="modal"
+          data-bs-target="#policyModal">
+    Disclosure & Privacy Policy
+  </button>
+</footer>
 
 </body>
 </html>

--- a/website/templates/dashboard.html
+++ b/website/templates/dashboard.html
@@ -1,163 +1,205 @@
 {% extends "base.html" %}
 
 {% block content %}
-<style>
-  .dashboard-game {
-    background: linear-gradient(135deg, #0f0c29 0%, #1a0a2e 30%, #16213e 60%, #0f3460 100%);
-    min-height: 80vh;
-    border-radius: 16px;
-    padding: 2rem;
-    position: relative;
-    overflow: hidden;
-  }
-  .dashboard-game::before {
-    content: "";
-    position: absolute;
-    top: 0; left: 0; right: 0; bottom: 0;
-    background-image: radial-gradient(circle at 20% 80%, rgba(0, 255, 255, 0.06) 0%, transparent 50%),
-                      radial-gradient(circle at 80% 20%, rgba(255, 0, 128, 0.06) 0%, transparent 50%);
-    pointer-events: none;
-  }
-  .dashboard-game .dashboard-title {
-    font-family: 'Segoe UI', system-ui, sans-serif;
-    font-weight: 800;
-    font-size: 1.75rem;
-    letter-spacing: 0.15em;
-    text-transform: uppercase;
-    background: linear-gradient(90deg, #00ffff, #ff00aa, #00ff88);
-    background-size: 200% auto;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin-bottom: 1.5rem;
-  }
-  .dashboard-game .stat-card {
-    background: rgba(15, 20, 45, 0.85);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 12px;
-    padding: 1.25rem;
-    text-align: center;
-    transition: transform 0.2s, box-shadow 0.2s;
-    position: relative;
-  }
-  .dashboard-game .stat-card:hover {
-    transform: translateY(-4px);
-  }
-  .dashboard-game .stat-card.cyan { box-shadow: 0 0 20px rgba(0, 255, 255, 0.25); border-color: rgba(0, 255, 255, 0.4); }
-  .dashboard-game .stat-card.magenta { box-shadow: 0 0 20px rgba(255, 0, 128, 0.25); border-color: rgba(255, 0, 128, 0.4); }
-  .dashboard-game .stat-card.lime { box-shadow: 0 0 20px rgba(0, 255, 136, 0.25); border-color: rgba(0, 255, 136, 0.4); }
-  .dashboard-game .stat-card.orange { box-shadow: 0 0 20px rgba(255, 165, 0, 0.25); border-color: rgba(255, 165, 0, 0.4); }
-  .dashboard-game .stat-card.purple { box-shadow: 0 0 20px rgba(168, 85, 247, 0.25); border-color: rgba(168, 85, 247, 0.4); }
-  .dashboard-game .stat-card .stat-label {
-    font-size: 0.8rem;
-    font-weight: 600;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    margin-bottom: 0.5rem;
-  }
-  .dashboard-game .stat-card.cyan .stat-label { color: #00ffff; }
-  .dashboard-game .stat-card.magenta .stat-label { color: #ff00aa; }
-  .dashboard-game .stat-card.lime .stat-label { color: #00ff88; }
-  .dashboard-game .stat-card.orange .stat-label { color: #ffa500; }
-  .dashboard-game .stat-card.purple .stat-label { color: #a855f7; }
-  .dashboard-game .stat-card .stat-value {
-    font-size: 2rem;
-    font-weight: 800;
-    color: #fff;
-    text-shadow: 0 0 20px rgba(255, 255, 255, 0.3);
-  }
-  .dashboard-game .stat-card .stat-hint {
-    font-size: 0.7rem;
-    color: rgba(255, 255, 255, 0.5);
-    margin-top: 0.35rem;
-  }
-</style>
 
 <div class="dashboard-game">
   <h2 class="dashboard-title">KPI Dashboard</h2>
 
+  <!-- Row 1: Core user metrics -->
+  <p class="section-label">Users</p>
   <div class="row g-3 mb-4">
     <div class="col-md-3">
       <div class="stat-card cyan">
-        <div class="stat-label">Unique participants (joined)</div>
+        <div class="stat-label">Unique participants</div>
         <div class="stat-value">{{ metrics.total_users }}</div>
         <div class="stat-hint">1 per person across sessions</div>
-      </div>
-    </div>
-    <div class="col-md-3">
-      <div class="stat-card magenta">
-        <div class="stat-label">Sessions Created (Total)</div>
-        <div class="stat-value">{{ metrics.sessions_created }}</div>
-        <div class="stat-hint">Total Sessions Created, Yay!</div>
-      </div>
-    </div>
-    <div class="col-md-3">
-      <div class="stat-card orange">
-        <div class="stat-label">Availability only</div>
-        <div class="stat-value">{{ metrics.availability_only_participants }}</div>
-        <div class="stat-hint">Submitted time slots, no confirmation</div>
       </div>
     </div>
     <div class="col-md-3">
       <div class="stat-card lime">
         <div class="stat-label">Confirmed participants</div>
         <div class="stat-value">{{ metrics.confirmed_participants }}</div>
-        <div class="stat-hint">RSVP’d for ≥1 session</div>
+        <div class="stat-hint">RSVP'd for ≥1 session</div>
       </div>
     </div>
-  </div>
-
-  <div class="row g-3 mb-4">
-    <div class="col-md-6">
+    <div class="col-md-3">
       <div class="stat-card orange">
-        <div class="stat-label">Activation Rate</div>
-        <div class="stat-value">{{ metrics.activation_rate }}</div>
-        <div class="stat-hint">% users who created or confirmed for ≥1 session</div>
+        <div class="stat-label">Availability only</div>
+        <div class="stat-value">{{ metrics.availability_only_participants }}</div>
+        <div class="stat-hint">Submitted slots, no confirmation</div>
       </div>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-3">
       <div class="stat-card purple">
-        <div class="stat-label">Repeat Usage</div>
+        <div class="stat-label">Repeat usage</div>
         <div class="stat-value">{{ metrics.repeat_usage }}</div>
-        <div class="stat-hint">% users who returned within 7 days</div>
+        <div class="stat-hint">% who returned within 7 days</div>
       </div>
     </div>
   </div>
 
-  <div class="panel mt-4 p-4">
-      <h4 class="mb-3 text-center">Registered Emails</h4>
-      <p class="text-center small mb-3" style="color: #aaa;">{{ metrics.unique_emails|length }} unique email(s) collected</p>
-      {% if metrics.unique_emails %}
-          <table class="table sessions-table">
-              <thead>
-                  <tr>
-                      <th>#</th>
-                      <th>Email</th>
-                  </tr>
-              </thead>
-              <tbody>
-                  {% for email in metrics.unique_emails %}
-                  <tr>
-                      <td>{{ loop.index }}</td>
-                      <td>{{ email }}</td>
-                  </tr>
-                  {% endfor %}
-              </tbody>
-          </table>
-      {% else %}
-          <p class="text-center small" style="color: #aaa;">No emails collected yet.</p>
-      {% endif %}
+  <!-- Row 2: Session metrics -->
+  <hr class="section-divider">
+  <p class="section-label">Sessions</p>
+  <div class="row g-3 mb-4">
+    <div class="col-md-3">
+      <div class="stat-card magenta">
+        <div class="stat-label">Sessions created</div>
+        <div class="stat-value">{{ metrics.sessions_created }}</div>
+        <div class="stat-hint">All time</div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="stat-card teal">
+        <div class="stat-label">Groups with &gt;1 participant</div>
+        <div class="stat-value">{{ metrics.multi_participant_rate }}</div>
+        <div class="stat-hint">Sessions someone actually joined</div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="stat-card blue">
+        <div class="stat-label">Completion rate</div>
+        <div class="stat-value">{{ metrics.completion_rate }}</div>
+        <div class="stat-hint">% sessions with a final time set</div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="stat-card cyan">
+        <div class="stat-label">Avg participants</div>
+        <div class="stat-value">{{ metrics.avg_participants }}</div>
+        <div class="stat-hint">Per session</div>
+      </div>
+    </div>
   </div>
 
+  <!-- Row 3: Engagement -->
+  <hr class="section-divider">
+  <p class="section-label">Engagement</p>
+  <div class="row g-3 mb-4">
+    <div class="col-md-4">
+      <div class="stat-card orange">
+        <div class="stat-label">Activation rate</div>
+        <div class="stat-value">{{ metrics.activation_rate }}</div>
+        <div class="stat-hint">% who hosted or confirmed ≥1 session</div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="stat-card lime">
+        <div class="stat-label">Sessions with game votes</div>
+        <div class="stat-value">{{ metrics.sessions_with_votes_pct }}</div>
+        <div class="stat-hint">At least one vote cast</div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <!-- placeholder for future metric -->
+      <div class="stat-card purple">
+        <div class="stat-label">Unique emails collected</div>
+        <div class="stat-value">{{ metrics.unique_emails | length }}</div>
+        <div class="stat-hint">Across all sessions</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Row 4: Top games + Confirmation breakdown -->
+  <hr class="section-divider">
+  <p class="section-label">Votes & confirmations</p>
+  <div class="row g-3 mb-4">
+
+    <div class="col-md-6">
+      <div class="stat-card teal" style="text-align:left;">
+        <div class="stat-label" style="color:#00d2b4;">Top voted games</div>
+        {% if metrics.top_games %}
+          {% set max_votes = metrics.top_games[0][1] %}
+          <div style="margin-top: 0.75rem;">
+            {% for game_name, count in metrics.top_games %}
+            <div class="game-bar-row">
+              <span class="game-bar-label">{{ game_name }}</span>
+              <div class="game-bar-track">
+                <div class="game-bar-fill" style="width: {{ (count / max_votes * 100) | int }}%"></div>
+              </div>
+              <span class="game-bar-count">{{ count }}</span>
+            </div>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p style="color: rgba(255,255,255,0.4); font-size: 0.8rem; margin-top: 0.75rem;">No votes yet.</p>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="col-md-6">
+      <div class="stat-card magenta" style="text-align:left;">
+        <div class="stat-label" style="color:#ff00aa;">Confirmation breakdown</div>
+        {% set cb = metrics.confirmation_breakdown %}
+        {% set total_confirmations = cb.Yes + cb.Maybe + cb.No %}
+        <div style="margin-top: 0.75rem;">
+          <div class="confirm-bar-row">
+            <span class="confirm-bar-label" style="color: #00ff88;">Yes</span>
+            <div class="confirm-bar-track">
+              <div class="confirm-bar-fill" style="width: {{ ((cb.Yes / total_confirmations * 100) | int) if total_confirmations else 0 }}%; height:100%; border-radius:3px; background:#00ff88;"></div>
+            </div>
+            <span class="confirm-bar-count">{{ cb.Yes }}</span>
+          </div>
+          <div class="confirm-bar-row">
+            <span class="confirm-bar-label" style="color: #ffa500;">Maybe</span>
+            <div class="confirm-bar-track">
+              <div class="confirm-bar-fill" style="width: {{ ((cb.Maybe / total_confirmations * 100) | int) if total_confirmations else 0 }}%; height:100%; border-radius:3px; background:#ffa500;"></div>
+            </div>
+            <span class="confirm-bar-count">{{ cb.Maybe }}</span>
+          </div>
+          <div class="confirm-bar-row">
+            <span class="confirm-bar-label" style="color: #ff4444;">No</span>
+            <div class="confirm-bar-track">
+              <div class="confirm-bar-fill" style="width: {{ ((cb.No / total_confirmations * 100) | int) if total_confirmations else 0 }}%; height:100%; border-radius:3px; background:#ff4444;"></div>
+            </div>
+            <span class="confirm-bar-count">{{ cb.No }}</span>
+          </div>
+          {% if total_confirmations == 0 %}
+          <p style="color: rgba(255,255,255,0.4); font-size: 0.8rem;">No confirmations yet.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- Emails table -->
+  <div class="panel mt-4 p-4">
+    <h4 class="mb-3 text-center">Registered emails</h4>
+    <p class="text-center small mb-3" style="color: #aaa;">{{ metrics.unique_emails|length }} unique email(s) collected</p>
+    {% if metrics.unique_emails %}
+      <table class="table sessions-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Email</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for email in metrics.unique_emails %}
+          <tr>
+            <td>{{ loop.index }}</td>
+            <td>{{ email }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p class="text-center small" style="color: #aaa;">No emails collected yet.</p>
+    {% endif %}
+  </div>
+
+  <!-- Testing tools -->
   <div class="mt-5 pt-4 border-top border-secondary">
     <h5 class="text-white-50 mb-2">Testing</h5>
     <form action="{{ url_for('main.reset_db') }}" method="POST" onsubmit="return confirm('Delete all data and reset the database?');">
       <button type="submit" class="btn btn-outline-danger">Reset database</button>
     </form>
   </div>
-  
+
   <form method="POST" action="/seed-test-data">
-    <button class="btn btn-outline-primary btn-sm">Seed Test Data</button>
+    <button class="btn btn-outline-primary btn-sm">Seed test data</button>
   </form>
+
 </div>
 {% endblock %}


### PR DESCRIPTION
# feat: dashboard KPIs + disclosure modal rewrite

## Summary

Two independent improvements shipped together:

1. **Dashboard** — expanded KPI coverage with 6 new metrics and two new data viz cards
2. **Disclosure modal** — rewritten content + scroll-to-agree gate

---

## Changes

### `website/metrics.py`
Added 6 new helper functions, each wrapped in `try/except SQLAlchemyError`:
- `_sessions_with_multiple_participants` — % of sessions where participant count > 1
- `_session_completion_rate` — % of sessions with a `final_time` set
- `_avg_participants_per_session` — average participant count across all sessions
- `_sessions_with_votes` — % of sessions with at least one `GameVote`
- `_top_games` — top 5 voted games by count using `Counter`
- `_confirmation_breakdown` — Yes / Maybe / No counts across all `Confirmation` rows

All 6 keys added to the `calculate_metrics()` return dict.

### `templates/dashboard.html`
- Reorganized stat cards into logical rows (Users / Sessions / Engagement)
- Added two new cards: **Top voted games** (horizontal bar chart) and **Confirmation breakdown** (Yes/Maybe/No bars reusing existing `.s-yes` / `.s-maybe` / `.s-no` status pill classes)
- No new CSS — all styling uses existing `main.css` classes

### `templates/base.html`
- Modal content rewritten to accurately describe what data is collected and why (email → personal link, final time notification, retention tracking)
- `backdrop: 'static', keyboard: false` — cannot dismiss without agreeing on first visit
- X button removed on first visit
- "I Agree" button disabled until user scrolls to bottom of modal body
- Footer link still opens the modal for returning users

### `tests/test_views.py`
- Updated `test_dashboard` monkeypatch to include all new metric keys

### `tests/test_metrics.py`
- Updated `test_calculate_metrics_no_data` assertions to cover new keys
- Added 6 new `_db_error` tests (one per new helper) using `monkeypatch` + `_raiser`

---
All existing tests pass. New tests cover the `except SQLAlchemyError` branches for each new metric helper.