### PR TITLE
Add experiment telemetry, consent & feedback

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,5 +11,5 @@ app = create_app()
 
 if __name__ == '__main__':
     # PORT from env (Heroku). Default 5001: macOS often reserves 5000 for AirPlay Receiver.
-    port = int(os.environ.get("PORT", 5001))
+    port = int(os.environ.get("PORT", 5000))
     socketio.run(app, debug=True, port=port)

--- a/website/models.py
+++ b/website/models.py
@@ -152,6 +152,18 @@ class ExperimentResult(db.Model):
         db.DateTime(timezone=True), nullable=False,
         default=lambda: datetime.now(timezone.utc)
     )
+    click_count = db.Column(db.Integer, default=0)
+    scroll_depth = db.Column(db.Float, default=0.0)
+    first_interaction_ms = db.Column(db.Integer, nullable=True)
+    used_calendar = db.Column(db.Boolean, default=False)
+    typed_game = db.Column(db.Boolean, default=False)
+
+    # Post-experiment feedback fields
+    ease_of_use = db.Column(db.Integer, nullable=True)
+    layout_clarity = db.Column(db.Integer, nullable=True)
+    noticed_first = db.Column(db.String(20), nullable=True)
+    real_use_likelihood = db.Column(db.Integer, nullable=True)
+    feedback_text = db.Column(db.Text, nullable=True)
 
     def __repr__(self):
         return f"<ExperimentResult condition={self.condition} joined={self.joined}>"

--- a/website/models.py
+++ b/website/models.py
@@ -158,6 +158,16 @@ class ExperimentResult(db.Model):
     used_calendar = db.Column(db.Boolean, default=False)
     typed_game = db.Column(db.Boolean, default=False)
 
+    # Extended behavioral metrics (collected by JS but previously not persisted)
+    calendar_block_count = db.Column(db.Integer, default=0)
+    calendar_section_ms = db.Column(db.Integer, default=0)
+    game_section_ms = db.Column(db.Integer, default=0)
+    time_to_calendar_ms = db.Column(db.Integer, nullable=True)
+    time_to_game_ms = db.Column(db.Integer, nullable=True)
+    rage_click_count = db.Column(db.Integer, default=0)
+    form_focus_ms = db.Column(db.Integer, default=0)
+    nudge_hover = db.Column(db.Boolean, default=False)
+
     # Post-experiment feedback fields
     ease_of_use = db.Column(db.Integer, nullable=True)
     layout_clarity = db.Column(db.Integer, nullable=True)

--- a/website/static/css/calendar.css
+++ b/website/static/css/calendar.css
@@ -11,3 +11,39 @@
 #group-calendar .fc-timegrid-col {
     touch-action: manipulation;
 }
+
+/* Hover over time slots */
+#group-calendar .fc-timegrid-slot:hover {
+    background: rgba(123, 47, 247, 0.12);
+    cursor: pointer;
+}
+
+/* When selecting (dragging) */
+.fc-highlight {
+    background: rgba(123, 47, 247, 0.35) !important;
+    border: 1px solid rgba(123, 47, 247, 0.6);
+}
+
+/* Existing availability blocks */
+.fc-bg-event {
+    backdrop-filter: blur(4px);
+    border-radius: 4px;
+    transition: transform 0.1s ease, opacity 0.15s ease;
+}
+
+/* Slight pop on hover */
+.fc-bg-event:hover {
+    transform: scale(1.02);
+    opacity: 0.85;
+}
+
+@keyframes pulseSelect {
+  0%   { transform: scale(1); opacity: 0.6; }
+  50%  { transform: scale(1.03); opacity: 1; }
+  100% { transform: scale(1); }
+}
+
+.fc-event-mirror {
+  animation: pulseSelect 0.25s ease;
+}
+

--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -985,3 +985,44 @@ input::placeholder {
   color: rgba(255, 255, 255, 0.85);
   margin-bottom: 0.4rem;
 }
+
+.exp-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2000;
+  display: none;
+  background: rgba(0,0,0,0.7);
+}
+
+.exp-modal.show {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.exp-modal-content {
+  background: #1e1e1e;
+  max-width: 900px;
+  width: 90%;
+  max-height: 85vh;
+  overflow-y: auto;
+  border-radius: 10px;
+  padding: 20px;
+  z-index: 2001;
+}
+
+.exp-detail-grid {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 8px 12px;
+
+  font-size: 0.9rem;
+  color: #ddd;
+}
+
+.exp-detail-grid b {
+  color: #ffffff;
+}

--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -871,3 +871,117 @@ hr {
     .host-controls-grid { grid-template-columns: 1fr; }
     .vote-field { max-width: 100%; }
 }
+
+.consent-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 17, 23, 1); /* fully opaque (alpha = 1) */
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 8vh;
+  z-index: 9999;
+  pointer-events: auto;
+  opacity: 1;
+  transition: opacity 0.35s ease;
+}
+
+.consent-overlay.fade-out {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.consent-box {
+    max-width: 720px;
+    max-height: 85vh;
+    overflow-y: auto;
+    padding: 24px;
+    border-radius: 12px;
+    background: #1c1c1c;
+    color: #eee;
+    pointer-events: auto;
+}
+
+.muted {
+    color: rgba(255,255,255,0.7);
+}
+
+.small-muted {
+    color: rgba(255,255,255,0.5);
+    font-size: 0.85rem;
+}
+
+.consent-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    margin-top: 10px;
+}
+
+.label {
+    font-weight: 600;
+    color: #00d4ff;
+}
+
+/* instruction colors */
+.step-dot {
+    display:inline-block;
+    width:10px;
+    height:10px;
+    border-radius:50%;
+    margin-right:8px;
+}
+
+.step-blue { background:#3b82f6; }
+.step-green { background:#22c55e; }
+.step-yellow { background:#eab308; }
+.step-purple { background:#a855f7; }
+
+.instruction-list {
+    padding-left: 18px;
+    line-height: 1.6;
+}
+
+.time-estimate {
+    margin-top: 16px;
+    color: rgba(255,255,255,0.75);
+}
+
+.consent-steps {
+  list-style: none;   /* removes default bullets */
+  padding-left: 0;
+  margin: 0;
+}
+
+.consent-steps li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+body.no-consent {
+  overflow: hidden;
+  height: 100vh;
+}
+
+.wrap-text {
+  max-width: 220px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+input::placeholder {
+  color: #aaa !important;
+  opacity: 1 !important;
+}
+
+.form-control::placeholder {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.form-label {
+  color: rgba(255, 255, 255, 0.85);
+  margin-bottom: 0.4rem;
+}

--- a/website/static/js/calendar.js
+++ b/website/static/js/calendar.js
@@ -132,6 +132,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
             if (window.isExperiment) {
                 window.tempBlocks.push({ start: info.startStr, end: info.endStr });
+                document.dispatchEvent(new CustomEvent('calendar:block_added'));
 
                 calendar.addEvent({
                     title: myName,

--- a/website/static/js/calendar.js
+++ b/website/static/js/calendar.js
@@ -128,6 +128,8 @@ document.addEventListener('DOMContentLoaded', function() {
         select: function(info) {
             if (!sessionHash && !window.isExperiment) return;
             
+            window.usedCalendar = true;
+
             if (window.isExperiment) {
                 window.tempBlocks.push({ start: info.startStr, end: info.endStr });
 
@@ -224,6 +226,7 @@ document.addEventListener('DOMContentLoaded', function() {
         },
 
         eventClick: function(info) {
+            window.usedCalendar = true;
             if (window.matchMedia('(pointer: coarse)').matches) return;
 
             // Check if it's "mine" in any of the three possible ways
@@ -262,6 +265,7 @@ document.addEventListener('DOMContentLoaded', function() {
         },
         
         eventDrop: function(info) {
+            window.usedCalendar = true;
             if (window.isExperiment) {
                 // Use extendedProps keys for matching — they're set at create-time
                 // and avoid any UTC-vs-local-offset mismatch with .toISOString().

--- a/website/templates/dashboard.html
+++ b/website/templates/dashboard.html
@@ -196,6 +196,18 @@
   }
   </script>
 
+    <!-- General Feedback Panel -->
+  <hr class="section-divider">
+    <p class="section-label">General Feedback</p>
+    <div class="panel mb-3 p-3">
+      <div class="d-flex align-items-center justify-content-between mb-2">
+        <h4 class="mb-0">Footer feedback submissions</h4>
+        <button class="btn btn-outline-secondary btn-sm" onclick="toggleFeedback(this)">Show</button>
+      </div>
+      <p class="text-center small mb-0" style="color:#aaa;" id="feedback-count">Loading…</p>
+      <div id="feedback-table" style="display:none; margin-top:1rem;"></div>
+  </div>
+  
   <!-- Experiment Panel -->
   <hr class="section-divider">
   <p class="section-label">Experiment — Join Flow A/B Test</p>
@@ -470,64 +482,133 @@
     fetch('/experiment/results')
       .then(r => r.json())
       .then(function(data) {
-        var aRows = data.filter(r => r.condition === 'A');
-        var bRows = data.filter(r => r.condition === 'B');
-        var aJoins = aRows.filter(r => r.joined).length;
-        var bJoins = bRows.filter(r => r.joined).length;
+
+        // -------------------------
+        // Split groups
+        // -------------------------
+        var a = data.filter(r => r.condition === 'A');
+        var b = data.filter(r => r.condition === 'B');
+
+        function safeAvg(arr, key) {
+          var vals = arr.map(x => x[key]).filter(v => v != null);
+          return vals.length ? vals.reduce((a,b)=>a+b,0)/vals.length : null;
+        }
+
+        function pct(arr, key) {
+          if (!arr.length) return 0;
+          return Math.round(arr.filter(x => x[key]).length / arr.length * 100);
+        }
+
+        // -------------------------
+        // JOIN RATE
+        // -------------------------
+        var aJoins = a.filter(r => r.joined).length;
+        var bJoins = b.filter(r => r.joined).length;
 
         document.getElementById('exp-a-joins').textContent =
-          aRows.length ? Math.round(aJoins / aRows.length * 100) + '%' : '—';
-        document.getElementById('exp-a-total').textContent =
-          aJoins + ' joined / ' + aRows.length + ' total';
+          a.length ? Math.round(aJoins / a.length * 100) + '%' : '—';
 
         document.getElementById('exp-b-joins').textContent =
-          bRows.length ? Math.round(bJoins / bRows.length * 100) + '%' : '—';
+          b.length ? Math.round(bJoins / b.length * 100) + '%' : '—';
+
+        document.getElementById('exp-a-total').textContent =
+          `${aJoins}/${a.length} joined`;
+
         document.getElementById('exp-b-total').textContent =
-          bJoins + ' joined / ' + bRows.length + ' total';
+          `${bJoins}/${b.length} joined`;
 
-        var timings = data.filter(r => r.joined && r.time_to_join_ms != null)
-                          .map(r => r.time_to_join_ms);
-        var avgTime = timings.length
-          ? Math.round(timings.reduce((a,b) => a+b, 0) / timings.length)
-          : null;
+        // -------------------------
+        // AVG TIME TO JOIN
+        // -------------------------
+        var avgTime = safeAvg(data.filter(r => r.joined), 'time_to_join_ms');
         document.getElementById('exp-avg-time').textContent =
-          avgTime != null ? (avgTime / 1000).toFixed(1) + 's' : '—';
+          avgTime ? (avgTime / 1000).toFixed(1) + 's' : '—';
 
+        // -------------------------
+        // NEW KPI EXTENSIONS
+        // -------------------------
+        var avgClicks = safeAvg(data, 'click_count');
+        var avgScroll = safeAvg(data, 'scroll_depth');
+        var firstInteractionAvg = safeAvg(data, 'first_interaction_time');
+
+        // optionally create new DOM fields if you want:
+        console.log("Avg clicks:", avgClicks);
+        console.log("Avg scroll:", avgScroll);
+        console.log("First interaction:", firstInteractionAvg);
+
+        // -------------------------
+        // BEHAVIOR COMPARISON (NEW)
+        // -------------------------
+        var calendarUsageA = pct(a, 'used_calendar');
+        var calendarUsageB = pct(b, 'used_calendar');
+
+        var typedGameA = pct(a, 'typed_game');
+        var typedGameB = pct(b, 'typed_game');
+
+        console.log("Calendar usage A/B:", calendarUsageA, calendarUsageB);
+        console.log("Typed game A/B:", typedGameA, typedGameB);
+
+        // -------------------------
+        // CHARTS (unchanged calls)
+        // -------------------------
         renderJoinTimeBarChart(data);
         renderAllJoinsBarChart(data);
 
+        // -------------------------
+        // TABLE (expanded)
+        // -------------------------
         if (data.length === 0) {
           document.getElementById('exp-results-table').innerHTML =
-            '<p style="color:rgba(255,255,255,0.3);font-size:0.85rem;">No results yet.</p>';
+            '<p style="color:rgba(255,255,255,0.3)">No results yet.</p>';
           return;
         }
-        var html = '<table class="table sessions-table"><thead><tr>' +
-          '<th>#</th><th>Condition</th><th>Joined</th>' +
-          '<th>Time to join</th><th>Recorded at</th>' +
-          '</tr></thead><tbody>';
+
+        var html = `
+          <table class="table sessions-table">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Cond</th>
+              <th>Joined</th>
+              <th>Time</th>
+              <th>Clicks</th>
+              <th>Scroll</th>
+              <th>Calendar</th>
+              <th>Typed Game</th>
+              <th>Created</th>
+            </tr>
+          </thead>
+          <tbody>
+        `;
+
         data.slice().reverse().forEach(function(r, i) {
-          var time = r.time_to_join_ms != null
-            ? (r.time_to_join_ms / 1000).toFixed(1) + 's' : '—';
-          var joined = r.joined
-            ? '<span class="status-pill s-yes">Yes</span>'
-            : '<span class="status-pill s-no">No</span>';
-          var ts = r.created_at ? new Date(r.created_at).toLocaleString() : '—';
-          html += '<tr><td>' + (data.length - i) + '</td>' +
-            '<td><strong>' + r.condition + '</strong></td>' +
-            '<td>' + joined + '</td>' +
-            '<td>' + time + '</td>' +
-            '<td style="font-size:0.8rem;color:#888;">' + ts + '</td></tr>';
+          html += `
+            <tr>
+              <td>${data.length - i}</td>
+              <td><b>${r.condition}</b></td>
+              <td>
+                <span class="status-pill ${r.joined ? 's-yes' : 's-no'}">
+                  ${r.joined ? 'Yes' : 'No'}
+                </span>
+              </td>
+              <td>${r.time_to_join_ms ? (r.time_to_join_ms/1000).toFixed(1)+'s' : '—'}</td>
+              <td>${r.click_count ?? '—'}</td>
+              <td>${r.scroll_depth ? Math.round(r.scroll_depth*100)+'%' : '—'}</td>
+              <td>${r.used_calendar ? 'Yes' : 'No'}</td>
+              <td>${r.typed_game ? 'Yes' : 'No'}</td>
+              <td style="font-size:0.8rem;color:#888;">
+                ${r.created_at ? new Date(r.created_at).toLocaleString() : '—'}
+              </td>
+            </tr>
+          `;
         });
-        html += '</tbody></table>';
+
+        html += `</tbody></table>`;
         document.getElementById('exp-results-table').innerHTML = html;
       })
       .catch(function() {
         document.getElementById('exp-results-table').innerHTML =
-          '<p style="color:#f87171;font-size:0.85rem;">Failed to load results.</p>';
-        var w = document.getElementById('exp-join-chart-wrap');
-        if (w) w.style.display = 'none';
-        var w2 = document.getElementById('exp-all-joins-chart-wrap');
-        if (w2) w2.style.display = 'none';
+          '<p style="color:#f87171">Failed to load results</p>';
       });
   }
 
@@ -565,6 +646,127 @@
   }
 
   loadExpResults();
+  </script>
+
+  <!-- Experiment Feedback Panel -->
+  <hr class="section-divider">
+  <p class="section-label">Experiment Feedback</p>
+  <div class="panel mb-3 p-3">
+    <div class="d-flex align-items-center justify-content-between mb-2">
+      <h4 class="mb-0">Post-experiment survey responses</h4>
+      <button class="btn btn-outline-secondary btn-sm" onclick="toggleExpFeedback(this)">Show</button>
+    </div>
+    <p class="text-center small mb-0" style="color:#aaa;" id="exp-feedback-count">Loading…</p>
+    <div id="exp-feedback-table" style="display:none; margin-top:1rem;"></div>
+  </div>
+
+  <script>
+  // ── General Feedback ──────────────────────────────────────────────────────
+  function toggleFeedback(btn) {
+    var el = document.getElementById('feedback-table');
+    var hidden = el.style.display === 'none';
+    el.style.display = hidden ? 'block' : 'none';
+    btn.textContent = hidden ? 'Hide' : 'Show';
+    if (hidden && el.innerHTML === '') loadFeedback();
+  }
+
+  function loadFeedback() {
+    fetch('/feedback/data')
+      .then(r => r.json())
+      .then(function(data) {
+        document.getElementById('feedback-count').textContent =
+          data.length + ' submission(s)';
+        if (!data.length) {
+          document.getElementById('feedback-table').innerHTML =
+            '<p class="text-center small" style="color:#aaa;">No feedback yet.</p>';
+          return;
+        }
+        var html = `<table class="table sessions-table"><thead><tr>
+          <th>#</th><th>Ease</th><th>Improvement</th><th>Goal?</th>
+          <th>Return</th><th>Recommend</th><th>Comments</th><th>Date</th>
+        </tr></thead><tbody>`;
+        data.slice().reverse().forEach(function(f, i) {
+          html += `<tr>
+            <td>${data.length - i}</td>
+            <td>${f.ease_of_use ?? '—'}</td>
+            <td class="wrap-text">${f.improvement || '—'}</td>
+            <td>${f.accomplished_goal || '—'}</td>
+            <td>${f.return_likelihood ?? '—'}</td>
+            <td>${f.recommend_likelihood ?? '—'}</td>
+            <td class="wrap-text">${f.additional_comments || '—'}</td>
+            <td style="font-size:0.8rem;color:#888;">${f.created_at ? new Date(f.created_at).toLocaleString() : '—'}</td>
+          </tr>`;
+        });
+        html += '</tbody></table>';
+        document.getElementById('feedback-table').innerHTML = html;
+      })
+      .catch(function() {
+        document.getElementById('feedback-table').innerHTML =
+          '<p style="color:#f87171">Failed to load feedback.</p>';
+      });
+  }
+
+  // Count on page load (don't show table yet)
+  fetch('/feedback/data').then(r => r.json()).then(function(data) {
+    document.getElementById('feedback-count').textContent = data.length + ' submission(s)';
+  }).catch(function() {
+    document.getElementById('feedback-count').textContent = 'Could not load';
+  });
+
+  // ── Experiment Feedback ───────────────────────────────────────────────────
+  function toggleExpFeedback(btn) {
+    var el = document.getElementById('exp-feedback-table');
+    var hidden = el.style.display === 'none';
+    el.style.display = hidden ? 'block' : 'none';
+    btn.textContent = hidden ? 'Hide' : 'Show';
+    if (hidden && el.innerHTML === '') loadExpFeedback();
+  }
+
+  function loadExpFeedback() {
+    fetch('/experiment/results')
+      .then(r => r.json())
+      .then(function(data) {
+        var withFeedback = data.filter(r =>
+          r.ease_of_use != null || r.layout_clarity != null || r.feedback_text
+        );
+        document.getElementById('exp-feedback-count').textContent =
+          withFeedback.length + ' response(s) with feedback';
+        if (!withFeedback.length) {
+          document.getElementById('exp-feedback-table').innerHTML =
+            '<p class="text-center small" style="color:#aaa;">No experiment feedback yet.</p>';
+          return;
+        }
+        var html = `<table class="table sessions-table"><thead><tr>
+          <th>#</th><th>Cond</th><th>Ease</th><th>Layout Clarity</th>
+          <th>Noticed First</th><th>Real Use</th><th>Improvement</th>
+        </tr></thead><tbody>`;
+        withFeedback.slice().reverse().forEach(function(r, i) {
+          html += `<tr>
+            <td>${r.id}</td>
+            <td><b>${r.condition}</b></td>
+            <td>${r.ease_of_use ?? '—'}</td>
+            <td>${r.layout_clarity ?? '—'}</td>
+            <td>${r.noticed_first || '—'}</td>
+            <td>${r.real_use_likelihood ?? '—'}</td>
+            <td class="wrap-text">${r.feedback_text || '—'}</td>
+          </tr>`;
+        });
+        html += '</tbody></table>';
+        document.getElementById('exp-feedback-table').innerHTML = html;
+      })
+      .catch(function() {
+        document.getElementById('exp-feedback-table').innerHTML =
+          '<p style="color:#f87171">Failed to load experiment feedback.</p>';
+      });
+  }
+
+  // Count on page load
+  fetch('/experiment/results').then(r => r.json()).then(function(data) {
+    var c = data.filter(r => r.ease_of_use != null || r.layout_clarity != null || r.feedback_text).length;
+    document.getElementById('exp-feedback-count').textContent = c + ' response(s) with feedback';
+  }).catch(function() {
+    document.getElementById('exp-feedback-count').textContent = 'Could not load';
+  });
   </script>
 
   <!-- Testing tools -->

--- a/website/templates/dashboard.html
+++ b/website/templates/dashboard.html
@@ -382,6 +382,14 @@
     });
   }
 
+  var modal = document.getElementById('exp-modal');
+    if (modal) {
+      modal.addEventListener('click', function(e) {
+        if (e.target.id === 'exp-modal') {
+          closeExpDetails();
+        }
+      });
+    }
   function renderJoinTimeBarChart(data) {
     var wrap = document.getElementById('exp-join-chart-wrap');
     var hint = document.getElementById('exp-join-chart-hint');
@@ -478,11 +486,59 @@
     });
   }
 
+  function fmtMs(ms) {
+    return ms == null ? '—' : (ms / 1000).toFixed(2) + 's';
+  }
+  function openExpDetails(id) {
+    const r = window.__EXP_DATA__?.find(x => String(x.id) === String(id));
+
+    if (!r) {
+      console.error("No record found for id:", id);
+      return;
+    }
+
+    const el = document.getElementById('exp-modal-body');
+
+    el.innerHTML = `
+      <div class="exp-detail-grid">
+
+        <div><b>Condition:</b></div><div>${r.condition ?? '—'}</div>
+        <div><b>Joined:</b></div><div>${r.joined ? 'Yes' : 'No'}</div>
+        <div><b>Time to join:</b></div><div>${r.time_to_join_ms != null ? (r.time_to_join_ms/1000).toFixed(2)+'s' : '—'}</div>
+        <div><b>First interaction:</b></div><div>${r.first_interaction_ms != null ? (r.first_interaction_ms/1000).toFixed(2)+'s' : '—'}</div>
+
+        <div><b>Clicks:</b></div><div>${r.click_count ?? '—'}</div>
+        <div><b>Scroll depth:</b></div><div>${r.scroll_depth != null ? Math.round(r.scroll_depth*100)+'%' : '—'}</div>
+
+        <div><b>Calendar used:</b></div><div>${r.used_calendar ? 'Yes' : 'No'}</div>
+        <div><b>Game typed:</b></div><div>${r.typed_game ? 'Yes' : 'No'}</div>
+
+        <div><b>Calendar dwell:</b></div><div>${fmtMs(r.calendar_section_ms)}</div>
+        <div><b>Time to calendar:</b></div><div>${fmtMs(r.time_to_calendar_ms)}</div>
+        <div><b>Game dwell:</b></div><div>${fmtMs(r.game_section_ms)}</div>
+        <div><b>Time to game:</b></div><div>${fmtMs(r.time_to_game_ms)}</div>
+        <div><b>Form focus:</b></div><div>${fmtMs(r.form_focus_ms)}</div>
+        <div><b>Rage clicks:</b></div><div>${r.rage_click_count ?? '—'}</div>
+
+        <div><b>Created:</b></div>
+        <div>${r.created_at ? new Date(r.created_at).toLocaleString() : '—'}</div>
+
+      </div>
+    `;
+    document.getElementById('exp-modal').classList.add('show');
+  }
+
+  function closeExpDetails() {
+    document.getElementById('exp-modal').classList.remove('show');
+  }
+
   function loadExpResults() {
     fetch('/experiment/results')
       .then(r => r.json())
       .then(function(data) {
+        window.__EXP_DATA__ = data;
 
+        
         // -------------------------
         // Split groups
         // -------------------------
@@ -570,11 +626,11 @@
               <th>#</th>
               <th>Cond</th>
               <th>Joined</th>
-              <th>Time</th>
+              <th>Time to join</th>
               <th>Clicks</th>
-              <th>Scroll</th>
-              <th>Calendar</th>
-              <th>Typed Game</th>
+              <th>Scroll %</th>
+              <th>Calendar used</th>
+              <th>Game typed</th>
               <th>Created</th>
             </tr>
           </thead>
@@ -582,8 +638,12 @@
         `;
 
         data.slice().reverse().forEach(function(r, i) {
+
+          var scrollPct = r.scroll_depth ? Math.round(r.scroll_depth * 100) : 0;
+          var time = r.time_to_join_ms ? (r.time_to_join_ms / 1000).toFixed(1) + 's' : '—';
+
           html += `
-            <tr>
+            <tr class="exp-row" onclick="openExpDetails(${JSON.stringify(r.id)})">
               <td>${data.length - i}</td>
               <td><b>${r.condition}</b></td>
               <td>
@@ -591,14 +651,12 @@
                   ${r.joined ? 'Yes' : 'No'}
                 </span>
               </td>
-              <td>${r.time_to_join_ms ? (r.time_to_join_ms/1000).toFixed(1)+'s' : '—'}</td>
+              <td>${time}</td>
               <td>${r.click_count ?? '—'}</td>
-              <td>${r.scroll_depth ? Math.round(r.scroll_depth*100)+'%' : '—'}</td>
+              <td>${scrollPct}%</td>
               <td>${r.used_calendar ? 'Yes' : 'No'}</td>
               <td>${r.typed_game ? 'Yes' : 'No'}</td>
-              <td style="font-size:0.8rem;color:#888;">
-                ${r.created_at ? new Date(r.created_at).toLocaleString() : '—'}
-              </td>
+              <td>${r.created_at ? new Date(r.created_at).toLocaleString() : '—'}</td>
             </tr>
           `;
         });
@@ -781,5 +839,15 @@
     <button class="btn btn-outline-primary btn-sm">Seed test data</button>
   </form>
 
+</div>
+<div id="exp-modal" class="exp-modal">
+  <div class="exp-modal-content">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <h5 class="mb-0">Participant Details</h5>
+      <button class="btn btn-sm btn-outline-secondary" onclick="closeExpDetails()">Close</button>
+    </div>
+
+    <div id="exp-modal-body"></div>
+  </div>
 </div>
 {% endblock %}

--- a/website/templates/experiment_feedback.html
+++ b/website/templates/experiment_feedback.html
@@ -1,0 +1,108 @@
+{% extends "base.html" %}
+{% block content %}
+
+{#
+  experiment_feedback.html
+  Served at /experiment/feedback?condition=A|B&result_id=<id>
+  Shown automatically after a participant joins; also reachable directly.
+#}
+
+<div class="panel mb-4 p-4 mx-auto" style="max-width: 560px;">
+
+  <div class="text-center mb-4">
+    <h2 class="fw-bold" style="color:#a78bfa;">You're in! 🎮</h2>
+    <p class="text">One last thing — 30 seconds of feedback helps us improve SynQ.</p>
+  </div>
+
+  <form action="{{ url_for('main.submit_experiment_feedback') }}" method="POST"
+        class="section-card p-4">
+
+    <input type="hidden" name="condition" value="{{ condition }}">
+    <input type="hidden" name="result_id" value="{{ result_id }}">
+
+    <div class="mb-4">
+      <label class="form-label small fw-bold mb-2">
+        How easy was it to find what you needed?
+      </label>
+      <select name="ease_of_use"
+              class="form-select join-input"
+              required>
+        <option value="" disabled selected>Select a rating…</option>
+        <option value="1">1 – Very Hard</option>
+        <option value="2">2 – Hard</option>
+        <option value="3">3 – Neutral</option>
+        <option value="4">4 – Easy</option>
+        <option value="5">5 – Very Easy</option>
+      </select>
+    </div>
+
+    <div class="mb-4">
+      <label class="form-label small fw-bold mb-2">
+        How clear was the page layout?
+      </label>
+      <select name="layout_clarity"
+              class="form-select join-input"
+              required>
+        <option value="" disabled selected>Select a rating…</option>
+        <option value="1">1 – Very Confusing</option>
+        <option value="2">2 – Confusing</option>
+        <option value="3">3 – Neutral</option>
+        <option value="4">4 – Clear</option>
+        <option value="5">5 – Very Clear</option>
+      </select>
+    </div>
+
+    <div class="mb-4">
+      <label class="form-label small fw-bold mb-2">
+        Which section did you notice first?
+      </label>
+      <div class="d-flex flex-wrap gap-3">
+        {% for val, label in [('squad','Squad list'), ('calendar','Schedule'), ('game_vote','Game vote'), ('unsure','Not sure')] %}
+        <div class="form-check">
+          <input class="form-check-input" type="radio"
+                 name="noticed_first" id="nf-{{ val }}" value="{{ val }}" required>
+          <label class="form-check-label" for="nf-{{ val }}">{{ label }}</label>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+
+    <div class="mb-4">
+      <label class="form-label small fw-bold mb-2">
+        How likely are you to use this app for real?
+      </label>
+      <select name="real_use_likelihood"
+              class="form-select join-input"
+              required>
+        <option value="" disabled selected>Select a rating…</option>
+        <option value="1">1 – Very Unlikely</option>
+        <option value="2">2 – Unlikely</option>
+        <option value="3">3 – Neutral</option>
+        <option value="4">4 – Likely</option>
+        <option value="5">5 – Very Likely</option>
+      </select>
+    </div>
+
+    <div class="mb-4">
+      <label class="form-label small fw-bold mb-2">
+        Anything you'd change? <span style="color:#888;">(optional)</span>
+      </label>
+      <textarea name="improvement" rows="2"
+                class="form-control join-input"
+                placeholder="Tell us your thoughts…"></textarea>
+    </div>
+
+    <div class="d-flex justify-content-between align-items-center">
+      <a href="{{ url_for('main.index') }}" class="btn btn-outline-secondary btn-sm">
+        Skip
+      </a>
+      <button type="submit" class="btn btn-primary px-4 fw-bold">
+        Submit & Finish
+      </button>
+    </div>
+
+  </form>
+
+</div>
+
+{% endblock %}

--- a/website/templates/experiment_session.html
+++ b/website/templates/experiment_session.html
@@ -332,18 +332,22 @@ let calendarSectionMs = 0, gameSectionMs = 0;
 let _calEnter = null, _gameEnter = null;
 
 const _sectionObs = new IntersectionObserver((entries) => {
-    if (!window.consentGiven) return;
     entries.forEach(entry => {
         const now = Date.now();
         const isCalendar = entry.target.id === 'calendar-section';
         const isGame     = entry.target.id === 'game-tally-list';
+        if (!window.consentGiven) {
+            if (isCalendar && entry.isIntersecting) { _calEnter = null; }
+            if (isGame && entry.isIntersecting) { _gameEnter = null; }
+            return;
+        }
         if (isCalendar) {
-            if (entry.isIntersecting) { _calEnter = now; }
-            else if (_calEnter) { calendarSectionMs += now - _calEnter; _calEnter = null; }
+            if (entry.isIntersecting && !_calEnter) { _calEnter = now; }
+            else if (!entry.isIntersecting && _calEnter) { calendarSectionMs += now - _calEnter; _calEnter = null; }
         }
         if (isGame) {
-            if (entry.isIntersecting) { _gameEnter = now; }
-            else if (_gameEnter) { gameSectionMs += now - _gameEnter; _gameEnter = null; }
+            if (entry.isIntersecting && !_gameEnter) { _gameEnter = now; }
+            else if (!entry.isIntersecting && _gameEnter) { gameSectionMs += now - _gameEnter; _gameEnter = null; }
         }
     });
 }, { threshold: 0.3 });
@@ -356,6 +360,24 @@ document.addEventListener('visibilitychange', () => {
     if (_calEnter)  { calendarSectionMs  += now - _calEnter;  _calEnter  = null; }
     if (_gameEnter) { gameSectionMs       += now - _gameEnter; _gameEnter = null; }
 });
+
+function _refreshSectionVisibility() {
+    if (!window.consentGiven) return;
+    const now = Date.now();
+    const calEl = document.getElementById('calendar-section');
+    const gameEl = document.getElementById('game-tally-list');
+    const inView = (el) => {
+        if (!el) return false;
+        const rect = el.getBoundingClientRect();
+        return rect.top < window.innerHeight && rect.bottom > 0;
+    };
+    if (calEl && !_calEnter && inView(calEl)) {
+        _calEnter = now;
+    }
+    if (gameEl && !_gameEnter && inView(gameEl)) {
+        _gameEnter = now;
+    }
+}
 
 // ── Rage-click detection ───────────────────────────────────────────────────
 let rageClickCount = 0;
@@ -399,6 +421,7 @@ function _stampMetrics() {
     document.getElementById('click-count-input').value          = clickCount;
     document.getElementById('scroll-depth-input').value         = maxScroll;
     document.getElementById('time-to-join-input').value         = _expStartMs ? now - _expStartMs : -1;
+    document.getElementById('temp-availability-input').value    = JSON.stringify(window.tempBlocks || []);
     document.getElementById('first-interaction-input').value    = window.firstInteractionTime || -1;
     document.getElementById('used-calendar-input').value        = window.usedCalendar ? 1 : 0;
     document.getElementById('typed-game-input').value           = window.typedGame ? 1 : 0;
@@ -479,6 +502,7 @@ function acceptConsent() {
     }, 350);
     window.consentGiven = true;
     _expStartMs = Date.now();   // ← timer starts HERE, only after agreement
+    _refreshSectionVisibility();
 }
 
 document.addEventListener("DOMContentLoaded", function () {

--- a/website/templates/experiment_session.html
+++ b/website/templates/experiment_session.html
@@ -11,6 +11,71 @@
   Timer starts on page load. On join submit, elapsed ms is posted with the form.
   On page unload without joining, a no_join beacon fires.
 #}
+<div id="consent-modal" class="consent-overlay">
+  <div class="consent-box">
+
+    <div id="consent-step-1">
+
+      <h3 class="mb-3">Informed Consent</h3>
+
+      <p class="muted">
+        SynQ Usability Study — CS422, Colby College
+      </p>
+
+      <p>
+        You are invited to participate in a research study conducted by students in CS422 at Colby College under Professor Naser Al Madi.
+      </p>
+
+      <div class="consent-grid">
+
+        <p><span class="label">Purpose</span><br>
+        Studying how scheduling design affects task completion.</p>
+
+        <p><span class="label">Data</span><br>
+        We collect clicks, scrolls, timing, and task completion. Email is collected only if you join. (As a user of our website)</p>
+
+        <p><span class="label">Risks</span><br>
+        No foreseeable risks.</p>
+
+        <p><span class="label">Confidentiality</span><br>
+        Data is anonymized and deleted by June 1, 2026.</p>
+
+      </div>
+
+      <p class="small-muted">
+        You may withdraw at any time without penalty.
+      </p>
+
+      <div class="d-flex justify-content-center mt-3">
+        <button class="btn btn-primary" onclick="goToInstructions()">
+            I Agree 
+        </button>
+      </div>
+
+    </div>
+        <div id="consent-step-2" style="display:none;">
+
+        <h3 class="mb-3">What You Will Do</h3>
+
+        <ul class="consent-steps">
+        <li><span class="step-dot step-blue"></span>Open the SynQ session page</li>
+        <li><span class="step-dot step-green"></span>Mark your availability on the calendar</li>
+        <li><span class="step-dot step-yellow"></span>Review group availability and game options</li>
+        <li><span class="step-dot step-purple"></span>Join the session by submitting the form</li>
+        </ul>
+
+        <p class="time-estimate">
+        ⏱ The task takes approximately <strong>5 minutes</strong>
+        </p>
+
+      <button class="btn btn-primary mt-3" onclick="acceptConsent()">
+        Start Task
+      </button>
+
+    </div>
+
+  </div>
+</div>
 
 <div class="panel mb-4 p-4">
 
@@ -132,6 +197,19 @@
                 <input type="hidden" name="link_token" value="{{ link_token }}">
                 <input type="hidden" name="time_to_join_ms" id="time-to-join-input" value="">
                 <input type="hidden" name="temp_availability" id="temp-availability-input" value="[]">
+                <input type="hidden" name="click_count" id="click-count-input">
+                <input type="hidden" name="scroll_depth" id="scroll-depth-input">
+                <input type="hidden" name="first_interaction_ms" id="first-interaction-input">
+                <input type="hidden" name="used_calendar" id="used-calendar-input">
+                <input type="hidden" name="typed_game" id="typed-game-input">
+                <input type="hidden" name="calendar_block_count" id="calendar-block-count-input" value="0">
+                <input type="hidden" name="calendar_section_ms"  id="calendar-section-ms-input"  value="0">
+                <input type="hidden" name="game_section_ms"      id="game-section-ms-input"      value="0">
+                <input type="hidden" name="time_to_calendar_ms"  id="time-to-calendar-ms-input"  value="-1">
+                <input type="hidden" name="time_to_game_ms"      id="time-to-game-ms-input"      value="-1">
+                <input type="hidden" name="rage_click_count"     id="rage-click-count-input"     value="0">
+                <input type="hidden" name="form_focus_ms"        id="form-focus-ms-input"        value="0">
+                <input type="hidden" name="nudge_hover"          id="nudge-hover-input"          value="0">
 
                 <div class="row g-3 mb-3">
                     <div class="col-sm-6">
@@ -168,8 +246,8 @@
 window.isExperiment = true;
 </script>
 <script>
-// ── Timer ─────────────────────────────────────────────────────────────────
-var _expStartMs = Date.now();
+// ── Timer (null until consent accepted) ───────────────────────────────────
+var _expStartMs = null;
 
 window.squadScheduleData = {{ grouped_json|tojson }};
 window.squadScheduleToken  = '';
@@ -177,6 +255,7 @@ window.squadScheduleHash = null;
 window.squadScheduleMyName = 'You (Unsaved)';
 window.squadIsHost         = false;
 window.squadToken          = '';
+window.consentGiven = false;
 </script>
 
 <link rel="stylesheet" href="/static/css/calendar.css">
@@ -186,31 +265,226 @@ window.squadToken          = '';
 <script src="/static/js/game_covers.js" defer></script>
 
 <script>
-// ── On join submit: stamp elapsed time + temp blocks ─────────────────────
-document.getElementById('experiment-join-form').addEventListener('submit', function() {
-    document.getElementById('time-to-join-input').value = Date.now() - _expStartMs;
-    if (window.tempBlocks && window.tempBlocks.length > 0) {
-        document.getElementById('temp-availability-input').value = JSON.stringify(window.tempBlocks);
-    }
+// ════════════════════════════════════════════════════════════════════════
+//  DEPENDENT VARIABLE TRACKING
+//  All counters/timers only run after consentGiven = true.
+// ════════════════════════════════════════════════════════════════════════
+
+// ── Basic ─────────────────────────────────────────────────────────────────
+let clickCount = 0;
+document.addEventListener('click', () => { if (window.consentGiven) clickCount++; });
+
+let maxScroll = 0;
+window.addEventListener('scroll', () => {
+    if (!window.consentGiven) return;
+    maxScroll = Math.max(maxScroll,
+        (window.scrollY + window.innerHeight) / document.body.scrollHeight);
 });
 
-// ── On unload without joining: fire no_join beacon ───────────────────────
+window.firstInteractionTime = null;
+function markInteraction() {
+    if (!window.consentGiven || window.firstInteractionTime || !_expStartMs) return;
+    window.firstInteractionTime = Date.now() - _expStartMs;
+}
+['click', 'keydown'].forEach(evt =>
+    document.addEventListener(evt, markInteraction, { once: true })
+);
+
+// ── Calendar interaction ───────────────────────────────────────────────────
+window.usedCalendar = false;
+window.calendarBlockCount = 0;
+window.timeToCalendarMs = null;
+
+// calendar.js fires 'calendar:block_added' each time a drag completes
+document.addEventListener('calendar:block_added', () => {
+    if (!window.consentGiven) return;
+    window.usedCalendar = true;
+    window.calendarBlockCount++;
+    if (_expStartMs && window.timeToCalendarMs === null)
+        window.timeToCalendarMs = Date.now() - _expStartMs;
+});
+document.addEventListener('mousedown', (e) => {
+    if (!window.consentGiven || !e.target.closest('#group-calendar')) return;
+    window.usedCalendar = true;
+    if (_expStartMs && window.timeToCalendarMs === null)
+        window.timeToCalendarMs = Date.now() - _expStartMs;
+});
+
+// ── Game vote interaction ──────────────────────────────────────────────────
+window.typedGame = false;
+window.timeToGameMs = null;
+
+document.querySelector('[name="game_name"]')?.addEventListener('input', () => {
+    if (!window.consentGiven) return;
+    window.typedGame = true;
+    if (_expStartMs && window.timeToGameMs === null)
+        window.timeToGameMs = Date.now() - _expStartMs;
+});
+document.querySelectorAll('.game-vote-card').forEach(card => {
+    card.addEventListener('click', () => {
+        if (!window.consentGiven || !_expStartMs || window.timeToGameMs !== null) return;
+        window.timeToGameMs = Date.now() - _expStartMs;
+    });
+});
+
+// ── Section dwell time (IntersectionObserver) ─────────────────────────────
+let calendarSectionMs = 0, gameSectionMs = 0;
+let _calEnter = null, _gameEnter = null;
+
+const _sectionObs = new IntersectionObserver((entries) => {
+    if (!window.consentGiven) return;
+    entries.forEach(entry => {
+        const now = Date.now();
+        const isCalendar = entry.target.id === 'calendar-section';
+        const isGame     = entry.target.id === 'game-tally-list';
+        if (isCalendar) {
+            if (entry.isIntersecting) { _calEnter = now; }
+            else if (_calEnter) { calendarSectionMs += now - _calEnter; _calEnter = null; }
+        }
+        if (isGame) {
+            if (entry.isIntersecting) { _gameEnter = now; }
+            else if (_gameEnter) { gameSectionMs += now - _gameEnter; _gameEnter = null; }
+        }
+    });
+}, { threshold: 0.3 });
+document.querySelectorAll('#calendar-section, #game-tally-list').forEach(el =>
+    _sectionObs.observe(el)
+);
+
+document.addEventListener('visibilitychange', () => {
+    const now = Date.now();
+    if (_calEnter)  { calendarSectionMs  += now - _calEnter;  _calEnter  = null; }
+    if (_gameEnter) { gameSectionMs       += now - _gameEnter; _gameEnter = null; }
+});
+
+// ── Rage-click detection ───────────────────────────────────────────────────
+let rageClickCount = 0;
+let _lastRageTarget = null, _lastRageTime = 0, _rageSeq = 0;
+document.addEventListener('click', (e) => {
+    if (!window.consentGiven) return;
+    const now = Date.now();
+    if (e.target === _lastRageTarget && now - _lastRageTime < 500) {
+        _rageSeq++;
+        if (_rageSeq >= 2) rageClickCount++;
+    } else { _rageSeq = 0; }
+    _lastRageTarget = e.target;
+    _lastRageTime = now;
+});
+
+// ── Form focus time ────────────────────────────────────────────────────────
+let formFocusMs = 0, _focusEnter = null;
+document.querySelectorAll('#experiment-join-form input, #experiment-join-form textarea').forEach(el => {
+    el.addEventListener('focus', () => { if (window.consentGiven) _focusEnter = Date.now(); });
+    el.addEventListener('blur',  () => {
+        if (_focusEnter) { formFocusMs += Date.now() - _focusEnter; _focusEnter = null; }
+    });
+});
+
+// ── Nudge-link hover ───────────────────────────────────────────────────────
+window.nudgeHover = false;
+document.querySelector('.join-nudge-link')?.addEventListener('mouseenter', () => {
+    if (window.consentGiven) window.nudgeHover = true;
+});
+
+// ════════════════════════════════════════════════════════════════════════
+//  HELPER — flush all metrics into hidden form fields
+// ════════════════════════════════════════════════════════════════════════
+function _stampMetrics() {
+    const now = Date.now();
+    // Flush any open section timers
+    if (_calEnter)  { calendarSectionMs  += now - _calEnter;  _calEnter  = null; }
+    if (_gameEnter) { gameSectionMs       += now - _gameEnter; _gameEnter = null; }
+    if (_focusEnter){ formFocusMs         += now - _focusEnter; _focusEnter = null; }
+
+    document.getElementById('click-count-input').value          = clickCount;
+    document.getElementById('scroll-depth-input').value         = maxScroll;
+    document.getElementById('time-to-join-input').value         = _expStartMs ? now - _expStartMs : -1;
+    document.getElementById('first-interaction-input').value    = window.firstInteractionTime || -1;
+    document.getElementById('used-calendar-input').value        = window.usedCalendar ? 1 : 0;
+    document.getElementById('typed-game-input').value           = window.typedGame ? 1 : 0;
+    document.getElementById('calendar-block-count-input').value = window.calendarBlockCount;
+    document.getElementById('calendar-section-ms-input').value  = calendarSectionMs;
+    document.getElementById('game-section-ms-input').value      = gameSectionMs;
+    document.getElementById('time-to-calendar-ms-input').value  = window.timeToCalendarMs ?? -1;
+    document.getElementById('time-to-game-ms-input').value      = window.timeToGameMs ?? -1;
+    document.getElementById('rage-click-count-input').value     = rageClickCount;
+    document.getElementById('form-focus-ms-input').value        = formFocusMs;
+    document.getElementById('nudge-hover-input').value          = window.nudgeHover ? 1 : 0;
+}
+
+// ════════════════════════════════════════════════════════════════════════
+//  JOIN FORM SUBMIT
+// ════════════════════════════════════════════════════════════════════════
 var _joined = false;
-document.getElementById('experiment-join-form').addEventListener('submit', function() {
+
+document.getElementById('experiment-join-form').addEventListener('submit', function(e) {
+    if (!_expStartMs) {
+        e.preventDefault();
+        alert("Please accept consent first.");
+        return;
+    }
+    _stampMetrics();
     _joined = true;
+    // Normal form POST proceeds — server redirects to /experiment/feedback
 });
 
+// ════════════════════════════════════════════════════════════════════════
+//  ABANDON BEACON
+// ════════════════════════════════════════════════════════════════════════
 window.addEventListener('beforeunload', function() {
-    if (_joined) return;
-    var elapsed = Date.now() - _expStartMs;
-    var fd = new FormData();
-    fd.append('condition', '{{ condition }}');
-    fd.append('time_to_join_ms', elapsed);
-    fd.append('link_token', '{{ link_token }}');
-    navigator.sendBeacon(
-        '{{ url_for("main.experiment_no_join") }}',
-        fd
-    );
+    if (_joined || !_expStartMs) return;   // guard: no beacon if consent never given
+
+    const now = Date.now();
+    if (_calEnter)  calendarSectionMs  += now - _calEnter;
+    if (_gameEnter) gameSectionMs       += now - _gameEnter;
+
+    const fd = new FormData();
+    fd.append('condition',            '{{ condition }}');
+    fd.append('link_token',           '{{ link_token }}');
+    fd.append('time_to_join_ms',      now - _expStartMs);
+    fd.append('click_count',          clickCount);
+    fd.append('scroll_depth',         maxScroll);
+    fd.append('first_interaction_ms', window.firstInteractionTime || -1);
+    fd.append('used_calendar',        window.usedCalendar ? 1 : 0);
+    fd.append('typed_game',           window.typedGame ? 1 : 0);
+    fd.append('calendar_block_count', window.calendarBlockCount);
+    fd.append('calendar_section_ms',  calendarSectionMs);
+    fd.append('game_section_ms',      gameSectionMs);
+    fd.append('time_to_calendar_ms',  window.timeToCalendarMs ?? -1);
+    fd.append('time_to_game_ms',      window.timeToGameMs ?? -1);
+    fd.append('rage_click_count',     rageClickCount);
+    fd.append('form_focus_ms',        formFocusMs);
+    fd.append('nudge_hover',          window.nudgeHover ? 1 : 0);
+    navigator.sendBeacon('{{ url_for("main.experiment_no_join") }}', fd);
+});
+
+// ════════════════════════════════════════════════════════════════════════
+//  CONSENT MODAL FLOW
+// ════════════════════════════════════════════════════════════════════════
+document.body.classList.add('no-consent');
+
+function goToInstructions() {
+    document.getElementById('consent-step-1').style.display = 'none';
+    document.getElementById('consent-step-2').style.display = 'block';
+}
+
+function acceptConsent() {
+    const modal = document.getElementById('consent-modal');
+    modal.classList.add('fade-out');
+    document.body.classList.remove('no-consent');
+    const scrollY = window.scrollY;
+    setTimeout(() => {
+        window.scrollTo(0, scrollY);
+        modal.style.display = 'none';
+    }, 350);
+    window.consentGiven = true;
+    _expStartMs = Date.now();   // ← timer starts HERE, only after agreement
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+    document.body.classList.add("no-consent");
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
 });
 </script>
 

--- a/website/views.py
+++ b/website/views.py
@@ -103,6 +103,16 @@ def _ensure_game_election_schema():
             ("availability", "start_time", "DATETIME"),
             ("availability", "end_time", "DATETIME"),
             ("experiment_result", "link_token", "VARCHAR(64)"),
+            ("experiment_result", "click_count", "INTEGER"),
+            ("experiment_result", "scroll_depth", "REAL"),
+            ("experiment_result", "first_interaction_ms", "INTEGER"),
+            ("experiment_result", "used_calendar", "INTEGER"),
+            ("experiment_result", "typed_game", "INTEGER"),
+            ("experiment_result", "ease_of_use", "INTEGER"),
+            ("experiment_result", "layout_clarity", "INTEGER"),
+            ("experiment_result", "noticed_first", "VARCHAR(20)"),
+            ("experiment_result", "real_use_likelihood", "INTEGER"),
+            ("experiment_result", "feedback_text", "TEXT"),
         ]:
             try:
                 conn.execute(text(f"ALTER TABLE {table} ADD COLUMN {col} {typ}"))
@@ -1071,25 +1081,64 @@ def import_db():
 # ── EXPERIMENT ROUTES ────────────────────────────────────────────────────────
 
 def _get_or_create_experiment_session():
-    """Return the single ExperimentSession template, creating it if needed."""
-    from website.models import ExperimentSession  # noqa: PLC0415
-    import json as _json  # noqa: PLC0415
-    from datetime import timezone, timedelta  # noqa: PLC0415
+    from website.models import ExperimentSession
+    import json as _json
+    import random
+    from datetime import datetime, timezone, timedelta
+
     es = ExperimentSession.query.first()
-    if not es:
-        now = datetime.now(timezone.utc).replace(hour=20, minute=0, second=0, microsecond=0)
-        blocks = []
-        for day_offset in [1, 2, 4, 5]:
-            day = now + timedelta(days=day_offset)
-            blocks.append({"start": day.replace(hour=18).isoformat(), "end": day.replace(hour=21).isoformat()})
-            blocks.append({"start": day.replace(hour=20).isoformat(), "end": day.replace(hour=22).isoformat()})
-        es = ExperimentSession(
-            title="Friday Night Games",
-            availability_json=_json.dumps(blocks),
-            chosen_game=None,
-        )
-        db.session.add(es)
-        db.session.commit()
+    if es:
+        return es
+
+    # Start from today, end June 1st
+    now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    end_date = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    people = ["Alex", "Jordan", "Sam", "Taylor"]
+    
+    # Common gaming windows (Start Hour, End Hour)
+    base_slots = [
+        (16, 18), (17, 19), (18, 20), 
+        (19, 21), (20, 22), (21, 23)
+    ]
+
+    blocks = []
+    current_day = now
+
+    while current_day < end_date:
+        # 1. Decide how many sessions happen this day (0 to 2 for realism)
+        # We don't want people gaming every single day, maybe 70% chance of sessions
+        if random.random() > 0.3:
+            num_sessions = random.randint(1, 2)
+            daily_slots = random.sample(base_slots, num_sessions)
+
+            for start_h, end_h in daily_slots:
+                start_dt = current_day.replace(hour=start_h)
+                end_dt = current_day.replace(hour=end_h)
+
+                # 2. Pick a group (2 to 4 people) who are "available" at this time
+                # This creates the "overlap" the users need to find!
+                group_size = random.choice([2, 3, 4])
+                participants = random.sample(people, group_size)
+
+                for person in participants:
+                    blocks.append({
+                        "person": person,
+                        "start": start_dt.isoformat(),
+                        "end": end_dt.isoformat()
+                    })
+
+        current_day += timedelta(days=1)
+
+    es = ExperimentSession(
+        title="Friday Night Games",
+        availability_json=_json.dumps(blocks),
+        chosen_game=None,
+    )
+
+    db.session.add(es)
+    db.session.commit()
+
     return es
 
 
@@ -1156,11 +1205,17 @@ def experiment_session():
     except (ValueError, TypeError):
         raw_blocks = []
 
-    grouped_json = {
-        "Alex":   [{"start": b["start"], "end": b["end"]} for b in raw_blocks[:3]],
-        "Jordan": [{"start": b["start"], "end": b["end"]} for b in raw_blocks[3:]],
-    }
-    fake_tally = [["Valorant", 2], ["Minecraft", 1]]
+    people = ["Alex", "Jordan", "Sam", "Taylor"]
+    grouped_json = {p: [] for p in people}
+
+    for b in raw_blocks:
+        person = b.get("person")
+        if person in grouped_json:
+            grouped_json[person].append({
+                "start": b["start"],
+                "end": b["end"]
+            })
+    fake_tally = [["Valorant", 2], ["Minecraft", 1], ["Overwatch", 1], ["Apex Legends", 1]]
 
     return render_template(
         "experiment_session.html",
@@ -1180,6 +1235,7 @@ def experiment_join():
     """Record a join event. Creates participant in __experiment__ session."""
     from website.models import ExperimentSession, ExperimentResult  # noqa: PLC0415
 
+    _ensure_game_election_schema()
     es = _get_or_create_experiment_session()
     condition = request.form.get("condition", "A").upper()
     time_to_join_ms = request.form.get("time_to_join_ms", type=int)
@@ -1187,6 +1243,11 @@ def experiment_join():
     email = (request.form.get("email") or "").strip()
     game_name = (request.form.get("game_name") or "").strip()
     temp_availability_raw = request.form.get("temp_availability", "[]")
+    click_count = request.form.get("click_count", type=int, default=0)
+    scroll_depth = request.form.get("scroll_depth", type=float, default=0.0)
+    first_interaction_ms = request.form.get("first_interaction_ms", type=int, default=-1)
+    used_calendar = request.form.get("used_calendar", type=int, default=0)
+    typed_game = request.form.get("typed_game", type=int, default=0)
 
     if not name:
         flash("Please enter your name.", "warning")
@@ -1238,8 +1299,28 @@ def experiment_join():
         ).fetchone()
         if result_row:
             db.session.execute(
-                text("UPDATE experiment_result SET participant_id=:pid, joined=true, time_to_join_ms=:ms WHERE id=:rid"),
-                {"pid": participant.id, "ms": time_to_join_ms, "rid": result_row[0]}
+                text("""
+                    UPDATE experiment_result 
+                    SET participant_id = :pid, 
+                        joined = true, 
+                        time_to_join_ms = :ms,
+                        click_count = :clicks,
+                        scroll_depth = :scroll,
+                        first_interaction_ms = :first_int,
+                        used_calendar = :used_cal,
+                        typed_game = :typed_g
+                    WHERE id = :rid
+                """),
+                {
+                    "pid": participant.id, 
+                    "ms": time_to_join_ms, 
+                    "clicks": click_count,
+                    "scroll": scroll_depth,
+                    "first_int": first_interaction_ms,
+                    "used_cal": bool(used_calendar),
+                    "typed_g": bool(typed_game),
+                    "rid": result_row[0]
+                }
             )
     else:
         db.session.add(ExperimentResult(
@@ -1248,12 +1329,27 @@ def experiment_join():
             participant_id=participant.id,
             joined=True,
             time_to_join_ms=time_to_join_ms,
+            click_count=click_count,
+            scroll_depth=scroll_depth, 
+            first_interaction_ms=first_interaction_ms,
+            used_calendar=used_calendar,
+            typed_game=typed_game,
         ))
     db.session.commit()
+    
+    result_id = request.form.get("result_id")
+    if not result_id:
+        # fallback lookup
+        result = ExperimentResult.query.filter_by(participant_id=participant.id).first()
+        result_id = result.id if result else None
 
     flash("Thanks! Your response has been recorded.", "success")
-    return redirect(url_for("main.index"))
 
+    return redirect(url_for(
+        "main.experiment_feedback",
+        condition=condition,
+        result_id = result.id if result else None
+    ))
 
 @main.route("/experiment/no_join", methods=["POST"])
 def experiment_no_join():
@@ -1352,10 +1448,25 @@ def experiment_results():
     """JSON endpoint for dashboard live panel."""
     from website.models import ExperimentResult  # noqa: PLC0415
     results = ExperimentResult.query.order_by(ExperimentResult.created_at).all()
-    return jsonify([{"id": r.id, "condition": r.condition, "joined": r.joined,
-                     "time_to_join_ms": r.time_to_join_ms,
-                     "created_at": r.created_at.isoformat() if r.created_at else None}
-                    for r in results])
+    def serialize_result(r):
+        return {
+            "id": r.id,
+            "condition": r.condition,
+            "joined": r.joined,
+            "time_to_join_ms": r.time_to_join_ms,
+            "click_count": r.click_count,
+            "scroll_depth": r.scroll_depth,
+            "first_interaction_ms": r.first_interaction_ms,
+            "used_calendar": r.used_calendar,
+            "typed_game": r.typed_game,
+            "ease_of_use": getattr(r, 'ease_of_use', None),
+            "layout_clarity": getattr(r, 'layout_clarity', None),
+            "noticed_first": getattr(r, 'noticed_first', None),
+            "real_use_likelihood": getattr(r, 'real_use_likelihood', None),
+            "feedback_text": getattr(r, 'feedback_text', None),
+            "created_at": r.created_at.isoformat() if r.created_at else None
+        }
+    return jsonify([serialize_result(r) for r in results])
 
 
 @main.route("/experiment/generate_link", methods=["POST"])
@@ -1393,6 +1504,22 @@ def cleanup_db():
     _reset_sequences()
     return "Done! Junk sessions deleted and sequences fixed."
 
+@main.route("/feedback/data")
+def feedback_data():
+    """JSON endpoint — all general feedback rows for the dashboard."""
+    rows = Feedback.query.order_by(Feedback.created_at).all()
+    return jsonify([{
+        "id": f.id,
+        "ease_of_use": f.ease_of_use,
+        "improvement": f.improvement,
+        "accomplished_goal": f.accomplished_goal,
+        "return_likelihood": f.return_likelihood,
+        "recommend_likelihood": f.recommend_likelihood,
+        "additional_comments": f.additional_comments,
+        "created_at": f.created_at.isoformat() if f.created_at else None,
+    } for f in rows])
+
+
 @main.route("/submit-feedback", methods=["POST"])
 def submit_feedback():
     """Handle feedback form submission from the footer modal."""
@@ -1428,4 +1555,61 @@ def submit_feedback():
 
     flash("Thank you for your feedback! It helps us improve SynQ.", "success")
     
-    return redirect(request.referrer or url_for("main.index"))
+    return redirect(url_for("main.index"))
+
+@main.route("/experiment/submit_feedback", methods=["POST"])
+def submit_experiment_feedback():
+    """Save experiment-specific feedback tied to an ExperimentResult row."""
+    from website.models import ExperimentResult  # noqa: PLC0415
+
+    result_id = request.form.get("result_id", type=int)
+    ease_of_use = request.form.get("ease_of_use")
+    layout_clarity = request.form.get("layout_clarity")
+    noticed_first = request.form.get("noticed_first")
+    real_use_likelihood = request.form.get("real_use_likelihood")
+    improvement = request.form.get("improvement", "").strip()
+
+    if result_id:
+        db.session.execute(
+            text("""
+                UPDATE experiment_result
+                SET ease_of_use         = :ease,
+                    layout_clarity      = :clarity,
+                    noticed_first       = :noticed,
+                    real_use_likelihood = :likelihood,
+                    feedback_text       = :improvement
+                WHERE id = :rid
+            """),
+            {
+                "ease": int(ease_of_use) if ease_of_use and ease_of_use.isdigit() else None,
+                "clarity": int(layout_clarity) if layout_clarity and layout_clarity.isdigit() else None,
+                "noticed": noticed_first,
+                "likelihood": int(real_use_likelihood) if real_use_likelihood and real_use_likelihood.isdigit() else None,
+                "improvement": improvement or None,
+                "rid": result_id,
+            }
+        )
+        db.session.commit()
+
+    flash("Thanks for the feedback!", "success")
+    return redirect(url_for("main.index"))
+
+
+@main.route("/experiment/feedback")
+def experiment_feedback():
+    from website.models import ExperimentResult  # import fixed
+
+    result_id = request.args.get("result_id", type=int)
+
+    if not result_id:
+        return redirect(url_for("main.index"))
+
+    result = ExperimentResult.query.get(result_id)
+    if not result:
+        return redirect(url_for("main.index"))
+
+    return render_template(
+        "experiment_feedback.html",
+        condition=result.condition,
+        result_id=result.id,
+    )

--- a/website/views.py
+++ b/website/views.py
@@ -108,6 +108,14 @@ def _ensure_game_election_schema():
             ("experiment_result", "first_interaction_ms", "INTEGER"),
             ("experiment_result", "used_calendar", "INTEGER"),
             ("experiment_result", "typed_game", "INTEGER"),
+            ("experiment_result", "calendar_block_count", "INTEGER"),
+            ("experiment_result", "calendar_section_ms", "INTEGER"),
+            ("experiment_result", "game_section_ms", "INTEGER"),
+            ("experiment_result", "time_to_calendar_ms", "INTEGER"),
+            ("experiment_result", "time_to_game_ms", "INTEGER"),
+            ("experiment_result", "rage_click_count", "INTEGER"),
+            ("experiment_result", "form_focus_ms", "INTEGER"),
+            ("experiment_result", "nudge_hover", "INTEGER"),
             ("experiment_result", "ease_of_use", "INTEGER"),
             ("experiment_result", "layout_clarity", "INTEGER"),
             ("experiment_result", "noticed_first", "VARCHAR(20)"),
@@ -1248,6 +1256,14 @@ def experiment_join():
     first_interaction_ms = request.form.get("first_interaction_ms", type=int, default=-1)
     used_calendar = request.form.get("used_calendar", type=int, default=0)
     typed_game = request.form.get("typed_game", type=int, default=0)
+    calendar_block_count = request.form.get("calendar_block_count", type=int, default=0)
+    calendar_section_ms = request.form.get("calendar_section_ms", type=int, default=0)
+    game_section_ms = request.form.get("game_section_ms", type=int, default=0)
+    time_to_calendar_ms = request.form.get("time_to_calendar_ms", type=int)
+    time_to_game_ms = request.form.get("time_to_game_ms", type=int)
+    rage_click_count = request.form.get("rage_click_count", type=int, default=0)
+    form_focus_ms = request.form.get("form_focus_ms", type=int, default=0)
+    nudge_hover = request.form.get("nudge_hover", type=int, default=0)
 
     if not name:
         flash("Please enter your name.", "warning")
@@ -1308,7 +1324,15 @@ def experiment_join():
                         scroll_depth = :scroll,
                         first_interaction_ms = :first_int,
                         used_calendar = :used_cal,
-                        typed_game = :typed_g
+                        typed_game = :typed_g,
+                        calendar_block_count = :cal_blocks,
+                        calendar_section_ms = :cal_ms,
+                        game_section_ms = :game_ms,
+                        time_to_calendar_ms = :ttcal,
+                        time_to_game_ms = :ttgame,
+                        rage_click_count = :rage,
+                        form_focus_ms = :focus_ms,
+                        nudge_hover = :nudge
                     WHERE id = :rid
                 """),
                 {
@@ -1319,6 +1343,14 @@ def experiment_join():
                     "first_int": first_interaction_ms,
                     "used_cal": bool(used_calendar),
                     "typed_g": bool(typed_game),
+                    "cal_blocks": calendar_block_count,
+                    "cal_ms": calendar_section_ms,
+                    "game_ms": game_section_ms,
+                    "ttcal": time_to_calendar_ms if time_to_calendar_ms and time_to_calendar_ms >= 0 else None,
+                    "ttgame": time_to_game_ms if time_to_game_ms and time_to_game_ms >= 0 else None,
+                    "rage": rage_click_count,
+                    "focus_ms": form_focus_ms,
+                    "nudge": bool(nudge_hover),
                     "rid": result_row[0]
                 }
             )
@@ -1334,6 +1366,14 @@ def experiment_join():
             first_interaction_ms=first_interaction_ms,
             used_calendar=used_calendar,
             typed_game=typed_game,
+            calendar_block_count=calendar_block_count,
+            calendar_section_ms=calendar_section_ms,
+            game_section_ms=game_section_ms,
+            time_to_calendar_ms=time_to_calendar_ms if time_to_calendar_ms and time_to_calendar_ms >= 0 else None,
+            time_to_game_ms=time_to_game_ms if time_to_game_ms and time_to_game_ms >= 0 else None,
+            rage_click_count=rage_click_count,
+            form_focus_ms=form_focus_ms,
+            nudge_hover=bool(nudge_hover),
         ))
     db.session.commit()
     
@@ -1357,11 +1397,57 @@ def experiment_no_join():
     from website.models import ExperimentSession, ExperimentResult  # noqa: PLC0415
     link_token = request.form.get("link_token", "").strip()
     elapsed = request.form.get("time_to_join_ms", type=int)
+    click_count = request.form.get("click_count", type=int, default=0)
+    scroll_depth = request.form.get("scroll_depth", type=float, default=0.0)
+    first_interaction_ms = request.form.get("first_interaction_ms", type=int)
+    used_calendar = request.form.get("used_calendar", type=int, default=0)
+    typed_game = request.form.get("typed_game", type=int, default=0)
+    calendar_block_count = request.form.get("calendar_block_count", type=int, default=0)
+    calendar_section_ms = request.form.get("calendar_section_ms", type=int, default=0)
+    game_section_ms = request.form.get("game_section_ms", type=int, default=0)
+    time_to_calendar_ms = request.form.get("time_to_calendar_ms", type=int)
+    time_to_game_ms = request.form.get("time_to_game_ms", type=int)
+    rage_click_count = request.form.get("rage_click_count", type=int, default=0)
+    form_focus_ms = request.form.get("form_focus_ms", type=int, default=0)
+    nudge_hover = request.form.get("nudge_hover", type=int, default=0)
 
     if link_token:
         db.session.execute(
-            text("UPDATE experiment_result SET time_to_join_ms=:ms WHERE link_token=:token AND joined=false"),
-            {"ms": elapsed, "token": link_token}
+            text("""
+                UPDATE experiment_result
+                SET time_to_join_ms      = :ms,
+                    click_count          = :clicks,
+                    scroll_depth         = :scroll,
+                    first_interaction_ms = :first_int,
+                    used_calendar        = :used_cal,
+                    typed_game           = :typed_g,
+                    calendar_block_count = :cal_blocks,
+                    calendar_section_ms  = :cal_ms,
+                    game_section_ms      = :game_ms,
+                    time_to_calendar_ms  = :ttcal,
+                    time_to_game_ms      = :ttgame,
+                    rage_click_count     = :rage,
+                    form_focus_ms        = :focus_ms,
+                    nudge_hover          = :nudge
+                WHERE link_token = :token AND joined = false
+            """),
+            {
+                "ms": elapsed,
+                "clicks": click_count,
+                "scroll": scroll_depth,
+                "first_int": first_interaction_ms if first_interaction_ms and first_interaction_ms >= 0 else None,
+                "used_cal": bool(used_calendar),
+                "typed_g": bool(typed_game),
+                "cal_blocks": calendar_block_count,
+                "cal_ms": calendar_section_ms,
+                "game_ms": game_section_ms,
+                "ttcal": time_to_calendar_ms if time_to_calendar_ms and time_to_calendar_ms >= 0 else None,
+                "ttgame": time_to_game_ms if time_to_game_ms and time_to_game_ms >= 0 else None,
+                "rage": rage_click_count,
+                "focus_ms": form_focus_ms,
+                "nudge": bool(nudge_hover),
+                "token": link_token,
+            }
         )
         db.session.commit()
     else:
@@ -1373,6 +1459,19 @@ def experiment_no_join():
             participant_id=None,
             joined=False,
             time_to_join_ms=elapsed,
+            click_count=click_count,
+            scroll_depth=scroll_depth,
+            first_interaction_ms=first_interaction_ms if first_interaction_ms and first_interaction_ms >= 0 else None,
+            used_calendar=bool(used_calendar),
+            typed_game=bool(typed_game),
+            calendar_block_count=calendar_block_count,
+            calendar_section_ms=calendar_section_ms,
+            game_section_ms=game_section_ms,
+            time_to_calendar_ms=time_to_calendar_ms if time_to_calendar_ms and time_to_calendar_ms >= 0 else None,
+            time_to_game_ms=time_to_game_ms if time_to_game_ms and time_to_game_ms >= 0 else None,
+            rage_click_count=rage_click_count,
+            form_focus_ms=form_focus_ms,
+            nudge_hover=bool(nudge_hover),
         ))
         db.session.commit()
     return jsonify({"ok": True})
@@ -1389,19 +1488,68 @@ def experiment_export():
     results = ExperimentResult.query.order_by(ExperimentResult.created_at).all()
 
     if fmt == "json":
-        data = [{"id": r.id, "condition": r.condition, "participant_id": r.participant_id,
-                 "joined": r.joined, "time_to_join_ms": r.time_to_join_ms,
-                 "created_at": r.created_at.isoformat() if r.created_at else None}
-                for r in results]
+        data = [{
+            "id": r.id,
+            "condition": r.condition,
+            "participant_id": r.participant_id,
+            "joined": r.joined,
+            "time_to_join_ms": r.time_to_join_ms,
+            "click_count": r.click_count,
+            "scroll_depth": r.scroll_depth,
+            "first_interaction_ms": r.first_interaction_ms,
+            "used_calendar": r.used_calendar,
+            "typed_game": r.typed_game,
+            "calendar_block_count": getattr(r, 'calendar_block_count', None),
+            "calendar_section_ms": getattr(r, 'calendar_section_ms', None),
+            "game_section_ms": getattr(r, 'game_section_ms', None),
+            "time_to_calendar_ms": getattr(r, 'time_to_calendar_ms', None),
+            "time_to_game_ms": getattr(r, 'time_to_game_ms', None),
+            "rage_click_count": getattr(r, 'rage_click_count', None),
+            "form_focus_ms": getattr(r, 'form_focus_ms', None),
+            "nudge_hover": getattr(r, 'nudge_hover', None),
+            "ease_of_use": getattr(r, 'ease_of_use', None),
+            "layout_clarity": getattr(r, 'layout_clarity', None),
+            "noticed_first": getattr(r, 'noticed_first', None),
+            "real_use_likelihood": getattr(r, 'real_use_likelihood', None),
+            "feedback_text": getattr(r, 'feedback_text', None),
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+        } for r in results]
         return Response(json.dumps(data, indent=2), mimetype="application/json",
                         headers={"Content-Disposition": "attachment; filename=experiment_results.json"})
 
+    EXPORT_FIELDS = [
+        "id", "condition", "participant_id", "joined",
+        "time_to_join_ms", "click_count", "scroll_depth", "first_interaction_ms",
+        "used_calendar", "typed_game",
+        "calendar_block_count", "calendar_section_ms", "game_section_ms",
+        "time_to_calendar_ms", "time_to_game_ms",
+        "rage_click_count", "form_focus_ms", "nudge_hover",
+        "ease_of_use", "layout_clarity", "noticed_first",
+        "real_use_likelihood", "feedback_text", "created_at",
+    ]
     out = io.StringIO()
     w = csv.writer(out)
-    w.writerow(["id", "condition", "participant_id", "joined", "time_to_join_ms", "created_at"])
+    w.writerow(EXPORT_FIELDS)
     for r in results:
-        w.writerow([r.id, r.condition, r.participant_id, r.joined, r.time_to_join_ms,
-                    r.created_at.isoformat() if r.created_at else ""])
+        w.writerow([
+            r.id, r.condition, r.participant_id, r.joined,
+            r.time_to_join_ms, r.click_count, r.scroll_depth, r.first_interaction_ms,
+            r.used_calendar, r.typed_game,
+            getattr(r, 'calendar_block_count', None),
+            getattr(r, 'calendar_section_ms', None),
+            getattr(r, 'game_section_ms', None),
+            getattr(r, 'time_to_calendar_ms', None),
+            getattr(r, 'time_to_game_ms', None),
+            getattr(r, 'rage_click_count', None),
+            getattr(r, 'form_focus_ms', None),
+            getattr(r, 'nudge_hover', None),
+            getattr(r, 'ease_of_use', None),
+            getattr(r, 'layout_clarity', None),
+            getattr(r, 'noticed_first', None),
+            getattr(r, 'real_use_likelihood', None),
+            getattr(r, 'feedback_text', None),
+            r.created_at.isoformat() if r.created_at else "",
+        ])
     return Response(out.getvalue(), mimetype="text/csv",
                     headers={"Content-Disposition": "attachment; filename=experiment_results.csv"})
 
@@ -1459,6 +1607,14 @@ def experiment_results():
             "first_interaction_ms": r.first_interaction_ms,
             "used_calendar": r.used_calendar,
             "typed_game": r.typed_game,
+            "calendar_block_count": getattr(r, 'calendar_block_count', None),
+            "calendar_section_ms": getattr(r, 'calendar_section_ms', None),
+            "game_section_ms": getattr(r, 'game_section_ms', None),
+            "time_to_calendar_ms": getattr(r, 'time_to_calendar_ms', None),
+            "time_to_game_ms": getattr(r, 'time_to_game_ms', None),
+            "rage_click_count": getattr(r, 'rage_click_count', None),
+            "form_focus_ms": getattr(r, 'form_focus_ms', None),
+            "nudge_hover": getattr(r, 'nudge_hover', None),
             "ease_of_use": getattr(r, 'ease_of_use', None),
             "layout_clarity": getattr(r, 'layout_clarity', None),
             "noticed_first": getattr(r, 'noticed_first', None),


### PR DESCRIPTION
Instrument experiment flow with telemetry and consent UI. Adds new fields to ExperimentResult (clicks, scroll, first interaction, calendar/game usage, and post-experiment feedback fields) and updates DB schema to include them. Implements a consent modal and starts the experiment timer only after consent; records many behavioral metrics (click counts, scroll depth, section dwell times, calendar interactions, game typing, rage clicks, form focus, nudge hover) and flushes them into hidden form fields. Adds abandon beacon to send metrics on no-join. Enhances experiment session generation with randomized availability blocks. Adds experiment feedback template and routes (/experiment/feedback, /experiment/submit_feedback) plus a /feedback/data endpoint and dashboard UI panels to display general and experiment feedback and expanded experiment result metrics. Includes UI/UX CSS adjustments (calendar and consent styles) and small JS changes to calendar handling. Also changes default app port to 5000.