### PR TITLE
Add Steam support, AI recommendation UI & tests

### DIFF
--- a/tests/test_steam.py
+++ b/tests/test_steam.py
@@ -1,0 +1,193 @@
+"""
+test_steam.py
+
+Unit tests for steam.py — resolve_steam_id() and get_steam_games()
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _mock_response(json_data: dict, raise_for_status: bool = False):
+    mock = MagicMock()
+    mock.json.return_value = json_data
+    if raise_for_status:
+        mock.raise_for_status.side_effect = Exception("HTTP Error")
+    else:
+        mock.raise_for_status.return_value = None
+    return mock
+
+
+# ===========================================================================
+# resolve_steam_id
+# ===========================================================================
+
+class TestResolveSteamId:
+
+    KEY = "FAKE_KEY"
+
+    def test_numeric_steam64_returned_directly(self):
+        from website.steam import resolve_steam_id
+        assert resolve_steam_id("76561198012345678", self.KEY) == "76561198012345678"
+
+    def test_numeric_steam64_with_whitespace(self):
+        from website.steam import resolve_steam_id
+        assert resolve_steam_id("  76561198012345678  ", self.KEY) == "76561198012345678"
+
+    def test_short_number_not_treated_as_steam64(self):
+        from website.steam import resolve_steam_id
+        with patch("website.steam.requests.get") as mock_get:
+            mock_get.return_value = _mock_response({"response": {"success": 42}})
+            assert resolve_steam_id("1234567", self.KEY) is None
+
+    def test_profiles_url_with_numeric_id(self):
+        from website.steam import resolve_steam_id
+        url = "https://steamcommunity.com/profiles/76561198012345678"
+        assert resolve_steam_id(url, self.KEY) == "76561198012345678"
+
+    def test_profiles_url_trailing_slash(self):
+        from website.steam import resolve_steam_id
+        url = "https://steamcommunity.com/profiles/76561198012345678/"
+        assert resolve_steam_id(url, self.KEY) == "76561198012345678"
+
+    def test_profiles_url_non_numeric_falls_through_to_vanity(self):
+        from website.steam import resolve_steam_id
+        with patch("website.steam.requests.get") as mock_get:
+            mock_get.return_value = _mock_response({"response": {"success": 42}})
+            assert resolve_steam_id(
+                "https://steamcommunity.com/profiles/notanumber", self.KEY
+            ) is None
+
+    def test_vanity_url_resolved_successfully(self):
+        from website.steam import resolve_steam_id
+        with patch("website.steam.requests.get") as mock_get:
+            mock_get.return_value = _mock_response({
+                "response": {"success": 1, "steamid": "76561198099999999"}
+            })
+            result = resolve_steam_id("https://steamcommunity.com/id/myvanity", self.KEY)
+        assert result == "76561198099999999"
+        assert mock_get.call_args[1]["params"]["vanityurl"] == "myvanity"
+
+    def test_vanity_url_trailing_slash(self):
+        from website.steam import resolve_steam_id
+        with patch("website.steam.requests.get") as mock_get:
+            mock_get.return_value = _mock_response({
+                "response": {"success": 1, "steamid": "76561198099999999"}
+            })
+            resolve_steam_id("https://steamcommunity.com/id/myvanity/", self.KEY)
+        assert mock_get.call_args[1]["params"]["vanityurl"] == "myvanity"
+
+    def test_vanity_url_not_found(self):
+        from website.steam import resolve_steam_id
+        with patch("website.steam.requests.get") as mock_get:
+            mock_get.return_value = _mock_response({"response": {"success": 42}})
+            assert resolve_steam_id("https://steamcommunity.com/id/nobody", self.KEY) is None
+
+    def test_raw_vanity_name_resolved(self):
+        from website.steam import resolve_steam_id
+        with patch("website.steam.requests.get") as mock_get:
+            mock_get.return_value = _mock_response({
+                "response": {"success": 1, "steamid": "76561198011111111"}
+            })
+            result = resolve_steam_id("gaben", self.KEY)
+        assert result == "76561198011111111"
+        assert mock_get.call_args[1]["params"]["vanityurl"] == "gaben"
+
+    def test_raw_vanity_name_not_found(self):
+        from website.steam import resolve_steam_id
+        with patch("website.steam.requests.get") as mock_get:
+            mock_get.return_value = _mock_response({"response": {"success": 42}})
+            assert resolve_steam_id("doesnotexist", self.KEY) is None
+
+
+# ===========================================================================
+# get_steam_games
+# ===========================================================================
+
+class TestGetSteamGames:
+
+    STEAM_ID = "76561198012345678"
+    KEY = "FAKE_KEY"
+
+    def _patch(self, recent_json, owned_json):
+        return patch("website.steam.requests.get", side_effect=[
+            _mock_response(recent_json),
+            _mock_response(owned_json),
+        ])
+
+    def test_returns_all_three_keys(self):
+        from website.steam import get_steam_games
+        with self._patch({"response": {"games": []}}, {"response": {"games": []}}):
+            result = get_steam_games(self.STEAM_ID, self.KEY)
+        assert set(result.keys()) == {"recent_games", "top_games", "all_names"}
+
+    def test_recent_games_extracted(self):
+        from website.steam import get_steam_games
+        with self._patch(
+            {"response": {"games": [{"name": "Game A"}, {"name": "Game B"}]}},
+            {"response": {"games": []}},
+        ):
+            result = get_steam_games(self.STEAM_ID, self.KEY)
+        assert result["recent_games"] == ["Game A", "Game B"]
+
+    def test_top_games_sorted_by_playtime(self):
+        from website.steam import get_steam_games
+        owned = [
+            {"name": "Low",  "playtime_forever": 10},
+            {"name": "High", "playtime_forever": 9999},
+            {"name": "Mid",  "playtime_forever": 500},
+        ]
+        with self._patch({"response": {"games": []}}, {"response": {"games": owned}}):
+            result = get_steam_games(self.STEAM_ID, self.KEY, top_n=2)
+        assert result["top_games"] == ["High", "Mid"]
+
+    def test_top_n_limits_results(self):
+        from website.steam import get_steam_games
+        owned = [{"name": f"Game {i}", "playtime_forever": i} for i in range(10, 0, -1)]
+        with self._patch({"response": {"games": []}}, {"response": {"games": owned}}):
+            result = get_steam_games(self.STEAM_ID, self.KEY, top_n=3)
+        assert len(result["top_games"]) == 3
+
+    def test_all_names_lowercased(self):
+        from website.steam import get_steam_games
+        owned = [{"name": "Counter-Strike 2", "playtime_forever": 100}]
+        with self._patch({"response": {"games": []}}, {"response": {"games": owned}}):
+            result = get_steam_games(self.STEAM_ID, self.KEY)
+        assert "counter-strike 2" in result["all_names"]
+        assert "Counter-Strike 2" not in result["all_names"]
+
+    def test_games_without_name_skipped(self):
+        from website.steam import get_steam_games
+        owned = [
+            {"appid": 730, "playtime_forever": 9999},         # no "name"
+            {"name": "Valve Game", "playtime_forever": 100},
+        ]
+        with self._patch({"response": {"games": []}}, {"response": {"games": owned}}):
+            result = get_steam_games(self.STEAM_ID, self.KEY)
+        assert result["top_games"] == ["Valve Game"]
+        assert "valve game" in result["all_names"]
+
+    def test_empty_library(self):
+        from website.steam import get_steam_games
+        with self._patch({"response": {}}, {"response": {}}):
+            result = get_steam_games(self.STEAM_ID, self.KEY)
+        assert result == {"recent_games": [], "top_games": [], "all_names": set()}
+
+    def test_http_error_on_recent_raises(self):
+        from website.steam import get_steam_games
+        with patch("website.steam.requests.get", return_value=_mock_response({}, raise_for_status=True)):
+            with pytest.raises(Exception, match="HTTP Error"):
+                get_steam_games(self.STEAM_ID, self.KEY)
+
+    def test_http_error_on_owned_raises(self):
+        from website.steam import get_steam_games
+        with patch("website.steam.requests.get", side_effect=[
+            _mock_response({"response": {"games": []}}),
+            _mock_response({}, raise_for_status=True),
+        ]):
+            with pytest.raises(Exception, match="HTTP Error"):
+                get_steam_games(self.STEAM_ID, self.KEY)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -202,3 +202,165 @@ def test_notify_feedback_handles_error(monkeypatch):
         
     assert success is False
     assert error == "SMTP feedback error"
+
+# ---------------------------------------------------------------------------
+# notify_personal_link
+# ---------------------------------------------------------------------------
+ 
+def _make_participant(name="Alice", email="alice@test.com", token="tok123"):
+    class P:
+        pass
+    p = P()
+    p.name, p.email, p.token = name, email, token
+    return p
+ 
+ 
+def _make_session_stub(title="Sprint Review", hash_id="hashxyz"):
+    class S:
+        pass
+    s = S()
+    s.title, s.hash_id = title, hash_id
+    return s
+ 
+ 
+def test_personal_link_success(monkeypatch):
+    """Returns (True, None) and calls mail.send on the happy path."""
+    from website.utils import notify_personal_link
+ 
+    flask_app = _make_app_with_mail()
+    sent = []
+    monkeypatch.setattr("website.utils.mail.send", lambda msg: sent.append(msg))
+ 
+    success, err = notify_personal_link(flask_app, _make_participant(), _make_session_stub())
+ 
+    assert success is True
+    assert err is None
+    assert len(sent) == 1
+ 
+ 
+def test_personal_link_no_mail_username(monkeypatch):
+    """Returns (False, None) early when MAIL_USERNAME is missing."""
+    from website.utils import notify_personal_link
+ 
+    flask_app = _make_app_with_mail()
+    flask_app.config["MAIL_USERNAME"] = None
+ 
+    success, err = notify_personal_link(flask_app, _make_participant(), _make_session_stub())
+ 
+    assert success is False
+    assert err is None
+ 
+ 
+def test_personal_link_no_mail_password(monkeypatch):
+    """Returns (False, None) early when MAIL_PASSWORD is missing."""
+    from website.utils import notify_personal_link
+ 
+    flask_app = _make_app_with_mail()
+    flask_app.config["MAIL_PASSWORD"] = ""
+ 
+    success, err = notify_personal_link(flask_app, _make_participant(), _make_session_stub())
+ 
+    assert success is False
+    assert err is None
+ 
+ 
+def test_personal_link_empty_email():
+    """Returns (False, None) when participant email is an empty string."""
+    from website.utils import notify_personal_link
+ 
+    flask_app = _make_app_with_mail()
+    p = _make_participant(email="")
+ 
+    success, err = notify_personal_link(flask_app, p, _make_session_stub())
+ 
+    assert success is False
+    assert err is None
+ 
+ 
+def test_personal_link_whitespace_email():
+    """Returns (False, None) when participant email is only whitespace."""
+    from website.utils import notify_personal_link
+ 
+    flask_app = _make_app_with_mail()
+    p = _make_participant(email="   ")
+ 
+    success, err = notify_personal_link(flask_app, p, _make_session_stub())
+ 
+    assert success is False
+    assert err is None
+ 
+ 
+def test_personal_link_none_email():
+    """Returns (False, None) when participant email is None."""
+    from website.utils import notify_personal_link
+ 
+    flask_app = _make_app_with_mail()
+    p = _make_participant(email=None)
+ 
+    success, err = notify_personal_link(flask_app, p, _make_session_stub())
+ 
+    assert success is False
+    assert err is None
+ 
+ 
+def test_personal_link_smtp_exception(monkeypatch):
+    """Returns (False, error_string) when mail.send raises."""
+    from website.utils import notify_personal_link
+ 
+    flask_app = _make_app_with_mail()
+    monkeypatch.setattr(
+        "website.utils.mail.send",
+        lambda msg: (_ for _ in ()).throw(RuntimeError("SMTP timeout")),
+    )
+ 
+    success, err = notify_personal_link(flask_app, _make_participant(), _make_session_stub())
+ 
+    assert success is False
+    assert "SMTP timeout" in err
+ 
+ 
+def test_personal_link_recipient_stripped(monkeypatch):
+    """Recipient in the sent message has surrounding whitespace removed."""
+    from website.utils import notify_personal_link
+ 
+    flask_app = _make_app_with_mail()
+    sent = []
+    monkeypatch.setattr("website.utils.mail.send", lambda msg: sent.append(msg))
+ 
+    p = _make_participant(email="  carol@test.com  ")
+    notify_personal_link(flask_app, p, _make_session_stub())
+ 
+    assert sent[0].recipients == ["carol@test.com"]
+ 
+ 
+def test_personal_link_subject_contains_session_title(monkeypatch):
+    """Email subject references the session title."""
+    from website.utils import notify_personal_link
+ 
+    flask_app = _make_app_with_mail()
+    sent = []
+    monkeypatch.setattr("website.utils.mail.send", lambda msg: sent.append(msg))
+ 
+    notify_personal_link(flask_app, _make_participant(), _make_session_stub(title="Q3 Retro"))
+ 
+    assert "Q3 Retro" in sent[0].subject
+ 
+ 
+def test_personal_link_body_contains_name_and_url(monkeypatch):
+    """Email body greets the participant by name and includes their personal URL."""
+    from website.utils import notify_personal_link
+ 
+    flask_app = _make_app_with_mail()
+    sent = []
+    monkeypatch.setattr("website.utils.mail.send", lambda msg: sent.append(msg))
+ 
+    notify_personal_link(
+        flask_app,
+        _make_participant(name="Dana", token="mytoken"),
+        _make_session_stub(hash_id="hashxyz"),
+    )
+ 
+    body = sent[0].body
+    assert "Dana" in body
+    assert "mytoken" in body or "hashxyz" in body   # URL contains one or both
+ 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2328,3 +2328,776 @@ def test_submit_feedback_invalid_integers(client, app, monkeypatch):
         assert fb.ease_of_use is None
         assert fb.return_likelihood is None
         assert fb.recommend_likelihood is None
+
+"""
+test_views_new.py
+
+Tests covering:
+- _emit_state: early return when game_session is None
+- experiment_session: ALTER TABLE (link_token column) on SQLite (idempotent),
+  and the `if not link_token` → 400 branch
+- experiment_join: ValueError in inner datetime parse (continue),
+  and JSONDecodeError/TypeError in outer json.loads (pass)
+- experiment_consent: `if not link_token` → 400 branch
+- feedback_data: rows returned as JSON list
+- ExperimentResult import inside submit_experiment_feedback,
+  and the full happy-path (result_id present → UPDATE, flash, redirect)
+- submit_experiment_feedback: `if not result_id` redirect and `if not result` redirect
+- set_steam:
+    - empty steam_input clears steam_id
+    - unresolvable steam id → 400
+    - private/unreachable library → 400
+    - happy path saves steam_id
+"""
+# pylint: disable=redefined-outer-name
+# pylint: disable=cyclic-import
+# pylint: disable=duplicate-code
+# pylint: disable=import-outside-toplevel
+
+import pytest
+
+from website import create_app, db
+from website.models import Session, Participant
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def app():
+    flask_app = create_app()
+    flask_app.config.update({
+        "TESTING": True,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "SQLALCHEMY_EXPIRE_ON_COMMIT": False,
+        "WTF_CSRF_ENABLED": False,
+    })
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def sample_session(app):
+    with app.app_context():
+        s = Session(title="Test Session", is_public=True)
+        db.session.add(s)
+        db.session.commit()
+
+        host = Participant(name="Host", email="host@test.com", session_id=s.id)
+        db.session.add(host)
+        db.session.commit()
+
+        s.host_id = host.id
+        db.session.commit()
+
+        return {
+            "session_id": s.id,
+            "session_hash": s.hash_id,
+            "host_id": host.id,
+            "host_token": host.token,
+        }
+
+
+# ── _emit_state: early return when session hash not found ─────────────────────
+
+def test_emit_state_missing_session_returns_silently(app):
+    """_emit_state should return without error when session hash doesn't exist."""
+    from website.views import _emit_state
+    with app.app_context():
+        # Should not raise anything — just an early return
+        _emit_state("nonexistent-hash-xyz")
+
+
+# ── experiment_session: no link_token → 400 ──────────────────────────────────
+
+def test_experiment_session_missing_token_returns_400(client):
+    """/experiment with no link_token should return 400."""
+    res = client.get("/experiment")
+    assert res.status_code == 400
+
+
+def test_experiment_session_empty_token_returns_400(client):
+    """/experiment with an empty link_token should return 400."""
+    res = client.get("/experiment?link_token=")
+    assert res.status_code == 400
+
+
+# ── experiment_session: ALTER TABLE idempotency ───────────────────────────────
+
+def test_experiment_session_alter_table_idempotent(client):
+    """Calling /experiment twice with a valid token should not crash on the
+    second ALTER TABLE (column already exists — exercises the except branch)."""
+    # Generate a valid token first
+    gen = client.post(
+        "/experiment/generate_link",
+        json={"condition": "A"},
+        content_type="application/json",
+    )
+    token = gen.get_json()["link_token"]
+
+    # First call: adds the column
+    res1 = client.get(f"/experiment?link_token={token}")
+    assert res1.status_code == 200
+
+    # Regenerate a fresh token (each token is single-use after consent)
+    gen2 = client.post(
+        "/experiment/generate_link",
+        json={"condition": "B"},
+        content_type="application/json",
+    )
+    token2 = gen2.get_json()["link_token"]
+
+    # Second call: column already exists — the except must swallow the error
+    res2 = client.get(f"/experiment?link_token={token2}")
+    assert res2.status_code == 200
+
+
+# ── experiment_join: ValueError in inner datetime parse ───────────────────────
+
+def test_experiment_join_invalid_availability_value_error_skipped(client):
+    """Bad ISO strings inside temp_availability blocks should be silently skipped
+    (ValueError → continue), and the join should still succeed."""
+    gen = client.post(
+        "/experiment/generate_link",
+        json={"condition": "A"},
+        content_type="application/json",
+    )
+    token = gen.get_json()["link_token"]
+
+    # Create the pending result row via consent
+    client.post(
+        "/experiment/consent",
+        data={"link_token": token, "condition": "A"},
+    )
+
+    bad_avail = '[{"start": "NOT-A-DATE", "end": "ALSO-BAD"}]'
+    res = client.post(
+        "/experiment/join",
+        data={
+            "name": "Tester",
+            "condition": "A",
+            "link_token": token,
+            "temp_availability": bad_avail,
+        },
+        follow_redirects=True,
+    )
+    assert res.status_code == 200
+
+
+# ── experiment_join: JSONDecodeError / TypeError in outer json.loads ──────────
+
+def test_experiment_join_invalid_json_availability_skipped(client):
+    """Completely malformed JSON in temp_availability should be silently skipped
+    (JSONDecodeError → pass), and the join should still succeed."""
+    gen = client.post(
+        "/experiment/generate_link",
+        json={"condition": "B"},
+        content_type="application/json",
+    )
+    token = gen.get_json()["link_token"]
+
+    client.post(
+        "/experiment/consent",
+        data={"link_token": token, "condition": "B"},
+    )
+
+    res = client.post(
+        "/experiment/join",
+        data={
+            "name": "JsonBreaker",
+            "condition": "B",
+            "link_token": token,
+            "temp_availability": "THIS IS NOT JSON {{{",
+        },
+        follow_redirects=True,
+    )
+    assert res.status_code == 200
+
+
+def test_experiment_join_null_availability_type_error_skipped(client):
+    """Passing None-like value for temp_availability (TypeError) should be
+    silently skipped, and the join should still succeed."""
+    gen = client.post(
+        "/experiment/generate_link",
+        json={"condition": "A"},
+        content_type="application/json",
+    )
+    token = gen.get_json()["link_token"]
+
+    client.post(
+        "/experiment/consent",
+        data={"link_token": token, "condition": "A"},
+    )
+
+    # Sending an integer string that json.loads will parse to int, not list
+    # This triggers the `(json.JSONDecodeError, TypeError): pass` branch
+    res = client.post(
+        "/experiment/join",
+        data={
+            "name": "TypeBreaker",
+            "condition": "A",
+            "link_token": token,
+            "temp_availability": "42",  # parses to int → TypeError on iteration
+        },
+        follow_redirects=True,
+    )
+    assert res.status_code == 200
+
+
+# ── experiment_consent: no link_token → 400 ───────────────────────────────────
+
+def test_experiment_consent_missing_token_returns_400(client):
+    """POST /experiment/consent with no token should return 400."""
+    res = client.post(
+        "/experiment/consent",
+        json={"condition": "A"},
+        content_type="application/json",
+    )
+    assert res.status_code == 400
+    data = res.get_json()
+    assert data["ok"] is False
+    assert "no token" in data["error"]
+
+
+def test_experiment_consent_empty_token_returns_400(client):
+    """POST /experiment/consent with empty token string should return 400."""
+    res = client.post(
+        "/experiment/consent",
+        json={"link_token": "", "condition": "A"},
+        content_type="application/json",
+    )
+    assert res.status_code == 400
+
+
+# ── feedback_data: JSON list of Feedback rows ─────────────────────────────────
+
+def test_feedback_data_returns_json_list(client, app):
+    """GET /feedback/data should return a JSON list of feedback rows."""
+    from website.models import Feedback
+
+    with app.app_context():
+        db.session.add(Feedback(
+            ease_of_use=5,
+            improvement="Make it faster",
+            accomplished_goal="Yes",
+            return_likelihood=4,
+            recommend_likelihood=5,
+            additional_comments="Great tool",
+        ))
+        db.session.commit()
+
+    res = client.get("/feedback/data")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    row = data[0]
+    assert "ease_of_use" in row
+    assert "improvement" in row
+    assert "accomplished_goal" in row
+    assert row["ease_of_use"] == 5
+
+
+def test_feedback_data_empty_returns_empty_list(client):
+    """GET /feedback/data with no rows should return an empty JSON list."""
+    res = client.get("/feedback/data")
+    assert res.status_code == 200
+    assert res.get_json() == []
+
+
+# ── submit_experiment_feedback: happy path with result_id ────────────────────
+
+def test_submit_experiment_feedback_with_valid_result_id(client, app):
+    """POST /experiment/submit_feedback with a valid result_id should UPDATE the
+    row, flash success, and redirect to index."""
+    from website.models import ExperimentResult
+
+    with app.app_context():
+        er = ExperimentResult(
+            condition="A",
+            experiment_session_id=None,
+            participant_id=None,
+            joined=True,
+            time_to_join_ms=1000,
+        )
+        db.session.add(er)
+        db.session.commit()
+        result_id = er.id
+
+    res = client.post(
+        "/experiment/submit_feedback",
+        data={
+            "result_id": result_id,
+            "ease_of_use": "4",
+            "layout_clarity": "3",
+            "noticed_first": "calendar",
+            "real_use_likelihood": "5",
+            "improvement": "Add dark mode",
+        },
+        follow_redirects=True,
+    )
+    assert res.status_code == 200
+    assert b"Thanks for the feedback" in res.data
+
+    with app.app_context():
+        er = ExperimentResult.query.get(result_id)
+        assert er.ease_of_use == 4
+        assert er.layout_clarity == 3
+        assert er.noticed_first == "calendar"
+        assert er.real_use_likelihood == 5
+        assert er.feedback_text == "Add dark mode"
+
+
+def test_submit_experiment_feedback_non_digit_values_stored_as_none(client, app):
+    """Non-digit scale values should be stored as NULL (None) rather than crashing."""
+    from website.models import ExperimentResult
+
+    with app.app_context():
+        er = ExperimentResult(
+            condition="B",
+            experiment_session_id=None,
+            participant_id=None,
+            joined=True,
+            time_to_join_ms=500,
+        )
+        db.session.add(er)
+        db.session.commit()
+        result_id = er.id
+
+    res = client.post(
+        "/experiment/submit_feedback",
+        data={
+            "result_id": result_id,
+            "ease_of_use": "not-a-number",
+            "layout_clarity": "",
+            "noticed_first": "game",
+            "real_use_likelihood": "abc",
+            "improvement": "",
+        },
+        follow_redirects=True,
+    )
+    assert res.status_code == 200
+
+    with app.app_context():
+        er = ExperimentResult.query.get(result_id)
+        assert er.ease_of_use is None
+        assert er.layout_clarity is None
+        assert er.real_use_likelihood is None
+
+
+def test_submit_experiment_feedback_no_result_id_redirects(client):
+    """POST /experiment/submit_feedback with no result_id should still flash and
+    redirect (the UPDATE block is skipped, flash always fires)."""
+    res = client.post(
+        "/experiment/submit_feedback",
+        data={
+            "ease_of_use": "3",
+            "layout_clarity": "3",
+            "noticed_first": "game",
+            "real_use_likelihood": "3",
+            "improvement": "Nothing",
+        },
+        follow_redirects=True,
+    )
+    assert res.status_code == 200
+    assert b"Thanks for the feedback" in res.data
+
+
+# ── experiment_feedback GET: no result_id → redirect ─────────────────────────
+
+def test_experiment_feedback_no_result_id_redirects(client):
+    """GET /experiment/feedback with no result_id should redirect to index."""
+    res = client.get("/experiment/feedback")
+    assert res.status_code == 302
+    assert "/" in res.headers["Location"]
+
+
+def test_experiment_feedback_nonexistent_result_id_redirects(client):
+    """GET /experiment/feedback with a result_id that doesn't exist should
+    redirect to index."""
+    res = client.get("/experiment/feedback?result_id=99999")
+    assert res.status_code == 302
+
+
+def test_experiment_feedback_valid_result_id_renders(client, app):
+    """GET /experiment/feedback with a valid result_id should render the page."""
+    from website.models import ExperimentResult
+
+    with app.app_context():
+        er = ExperimentResult(
+            condition="A",
+            experiment_session_id=None,
+            participant_id=None,
+            joined=True,
+            time_to_join_ms=200,
+        )
+        db.session.add(er)
+        db.session.commit()
+        result_id = er.id
+
+    res = client.get(f"/experiment/feedback?result_id={result_id}")
+    assert res.status_code == 200
+
+
+# ── set_steam: empty input clears steam_id ───────────────────────────────────
+
+def test_set_steam_empty_input_clears_steam_id(client, app, sample_session):
+    """Posting an empty steam_input should set steam_id to None and return ok."""
+    with app.app_context():
+        p = Participant.query.get(sample_session["host_id"])
+        p.steam_id = "76561198000000000"
+        db.session.commit()
+
+    res = client.post(
+        f"/session/{sample_session['session_hash']}/set_steam",
+        data={
+            "token": sample_session["host_token"],
+            "steam_input": "",
+        },
+    )
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["ok"] is True
+
+    with app.app_context():
+        p = Participant.query.get(sample_session["host_id"])
+        assert p.steam_id is None
+
+
+def test_set_steam_whitespace_only_clears_steam_id(client, app, sample_session):
+    """Whitespace-only steam_input should also clear steam_id."""
+    res = client.post(
+        f"/session/{sample_session['session_hash']}/set_steam",
+        data={
+            "token": sample_session["host_token"],
+            "steam_input": "   ",
+        },
+    )
+    assert res.status_code == 200
+    assert res.get_json()["ok"] is True
+
+
+# ── set_steam: unresolvable ID → 400 ─────────────────────────────────────────
+
+def test_set_steam_unresolvable_id_returns_400(client, app, sample_session, monkeypatch):
+    """resolve_steam_id returning None should yield a 400 with an error message."""
+    monkeypatch.setattr("website.views.resolve_steam_id", lambda raw, key: None)
+
+    res = client.post(
+        f"/session/{sample_session['session_hash']}/set_steam",
+        data={
+            "token": sample_session["host_token"],
+            "steam_input": "not-a-real-profile",
+        },
+    )
+    assert res.status_code == 400
+    data = res.get_json()
+    assert data["ok"] is False
+    assert "Could not resolve" in data["error"]
+
+
+# ── set_steam: private/unreachable library → 400 ─────────────────────────────
+
+def test_set_steam_private_library_returns_400(client, app, sample_session, monkeypatch):
+    """get_steam_games raising an exception should yield a 400 about private library."""
+    monkeypatch.setattr("website.views.resolve_steam_id", lambda raw, key: "76561198000000001")
+    monkeypatch.setattr("website.views.get_steam_games", lambda sid, key, top_n: (_ for _ in ()).throw(Exception("private")))
+
+    res = client.post(
+        f"/session/{sample_session['session_hash']}/set_steam",
+        data={
+            "token": sample_session["host_token"],
+            "steam_input": "someprofile",
+        },
+    )
+    assert res.status_code == 400
+    data = res.get_json()
+    assert data["ok"] is False
+    assert "private" in data["error"].lower() or "unreachable" in data["error"].lower()
+
+
+# ── set_steam: happy path saves steam_id ─────────────────────────────────────
+
+def test_set_steam_happy_path_saves_steam_id(client, app, sample_session, monkeypatch):
+    """Valid steam input should save the resolved steam_id and return it."""
+    fake_steam_id = "76561198012345678"
+    monkeypatch.setattr("website.views.resolve_steam_id", lambda raw, key: fake_steam_id)
+    monkeypatch.setattr("website.views.get_steam_games", lambda sid, key, top_n: {
+        "recent_games": [], "top_games": [], "all_names": set()
+    })
+
+    res = client.post(
+        f"/session/{sample_session['session_hash']}/set_steam",
+        data={
+            "token": sample_session["host_token"],
+            "steam_input": "https://steamcommunity.com/id/someuser",
+        },
+    )
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["ok"] is True
+    assert data["steam_id"] == fake_steam_id
+
+    with app.app_context():
+        p = Participant.query.get(sample_session["host_id"])
+        assert p.steam_id == fake_steam_id
+
+def test_recommend_game_success(client, app):
+    """Test successful recommend_game response with mocked AI output."""
+    from unittest.mock import patch, Mock
+
+    session = Session(hash_id="testhash")
+    db.session.add(session)
+    db.session.flush()
+
+    host = Participant(
+        name="Host",
+        token="host-token",
+        session_id=session.id,
+    )
+    db.session.add(host)
+    db.session.flush()
+
+    session.host_id = host.id
+
+    vote = GameVote(
+        session_id=session.id,
+        participant_id=host.id,
+        game_name="Deep Rock Galactic",
+    )
+    db.session.add(vote)
+    db.session.commit()
+
+    app.config["STEAM_API_KEY"] = "fake-steam"
+    app.config["HUGGINGFACE_API_KEY"] = "fake-hf"
+
+    mock_hf_response = Mock()
+    mock_hf_response.status_code = 200
+    mock_hf_response.json.return_value = {
+        "choices": [
+            {
+                "message": {
+                    "content": """
+                    {
+                      "picks": [
+                        {"game": "Deep Rock Galactic", "reason": "Great coop."},
+                        {"game": "Valheim", "reason": "Fun survival."},
+                        {"game": "Phasmophobia", "reason": "Scary teamwork."},
+                        {"game": "Helldivers 2", "reason": "Chaotic coop."}
+                      ]
+                    }
+                    """
+                }
+            }
+        ]
+    }
+
+    with patch("requests.post", return_value=mock_hf_response):
+        response = client.post(
+            "/session/testhash/recommend_game",
+            data={"token": "host-token"},
+        )
+
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert data["ok"] is True
+    assert len(data["picks"]) == 4
+
+def test_recommend_game_unauthorized(client):
+    """Non-host participants cannot request recommendations."""
+    session = Session(hash_id="testhash")
+    db.session.add(session)
+    db.session.flush()
+
+    host = Participant(name="Host", token="host-token", session_id=session.id)
+    other = Participant(name="Other", token="other-token", session_id=session.id)
+
+    db.session.add_all([host, other])
+    db.session.flush()
+
+    session.host_id = host.id
+    db.session.commit()
+
+    response = client.post(
+        "/session/testhash/recommend_game",
+        data={"token": "other-token"},
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["ok"] is False
+
+def test_recommend_game_model_error(client, app):
+    """Model API failure returns 503."""
+    from unittest.mock import patch, Mock
+
+    session = Session(hash_id="testhash")
+    db.session.add(session)
+    db.session.flush()
+
+    host = Participant(name="Host", token="host-token", session_id=session.id)
+    db.session.add(host)
+    db.session.flush()
+
+    session.host_id = host.id
+    db.session.commit()
+
+    app.config["HUGGINGFACE_API_KEY"] = "fake"
+
+    mock_resp = Mock()
+    mock_resp.status_code = 500
+    mock_resp.text = "Internal Error"
+
+    with patch("requests.post", return_value=mock_resp):
+        response = client.post(
+            "/session/testhash/recommend_game",
+            data={"token": "host-token"},
+        )
+
+    assert response.status_code == 503
+    assert response.get_json()["ok"] is False
+
+def test_recommend_game_unparseable_response(client, app):
+    """Invalid model output returns parse error."""
+    from unittest.mock import patch, Mock
+
+    session = Session(hash_id="testhash")
+    db.session.add(session)
+    db.session.flush()
+
+    host = Participant(name="Host", token="host-token", session_id=session.id)
+    db.session.add(host)
+    db.session.flush()
+
+    session.host_id = host.id
+    db.session.commit()
+
+    app.config["HUGGINGFACE_API_KEY"] = "fake"
+
+    mock_resp = Mock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "choices": [{"message": {"content": "not valid json"}}]
+    }
+
+    with patch("requests.post", return_value=mock_resp):
+        response = client.post(
+            "/session/testhash/recommend_game",
+            data={"token": "host-token"},
+        )
+
+    assert response.status_code == 500
+    assert response.get_json()["ok"] is False
+
+def test_recommend_game_ownership_filter_no_matches(client, app):
+    """Returns graceful message if ownership filter removes all picks."""
+    from unittest.mock import patch, Mock
+
+    session = Session(hash_id="testhash")
+    db.session.add(session)
+    db.session.flush()
+
+    host = Participant(
+        name="Host",
+        token="host-token",
+        session_id=session.id,
+        steam_id="123"
+    )
+    db.session.add(host)
+    db.session.flush()
+
+    session.host_id = host.id
+    db.session.commit()
+
+    app.config["STEAM_API_KEY"] = "fake"
+    app.config["HUGGINGFACE_API_KEY"] = "fake"
+
+    mock_resp = Mock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "choices": [{
+            "message": {
+                "content": """
+                {
+                  "picks": [
+                    {"game": "Unknown Game", "reason": "Why not"}
+                  ]
+                }
+                """
+            }
+        }]
+    }
+
+    with patch("website.views.get_steam_games") as mock_steam, \
+         patch("requests.post", return_value=mock_resp):
+
+        mock_steam.return_value = {
+            "recent_games": [],
+            "top_games": [],
+            "all_names": {"owned game"}
+        }
+
+        response = client.post(
+            "/session/testhash/recommend_game",
+            data={
+                "token": "host-token",
+                "ownership_filter": "all",
+            },
+        )
+
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert data["ok"] is False
+    assert "No recommendations passed" in data["error"]
+
+def test_recommend_game_steam_failure_ignored(client, app):
+    """Steam lookup failures should not break recommendation."""
+    from unittest.mock import patch, Mock
+
+    session = Session(hash_id="testhash")
+    db.session.add(session)
+    db.session.flush()
+
+    host = Participant(
+        name="Host",
+        token="host-token",
+        session_id=session.id,
+        steam_id="123"
+    )
+    db.session.add(host)
+    db.session.flush()
+
+    session.host_id = host.id
+    db.session.commit()
+
+    app.config["STEAM_API_KEY"] = "fake"
+    app.config["HUGGINGFACE_API_KEY"] = "fake"
+
+    mock_resp = Mock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "choices": [{
+            "message": {
+                "content": '{"picks":[{"game":"Valheim","reason":"Good"}]}'
+            }
+        }]
+    }
+
+    with patch("website.views.get_steam_games", side_effect=Exception("Steam fail")), \
+         patch("requests.post", return_value=mock_resp):
+
+        response = client.post(
+            "/session/testhash/recommend_game",
+            data={"token": "host-token"},
+        )
+
+    assert response.status_code == 200
+    assert response.get_json()["ok"] is True

--- a/website/__init__.py
+++ b/website/__init__.py
@@ -28,6 +28,8 @@ def create_app():
     app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "dev")
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     app.config["RAWG_API_KEY"] = os.environ.get("RAWG_API_KEY", "")
+    app.config['HUGGINGFACE_API_KEY'] = os.environ.get('HUGGINGFACE_API_KEY', '')
+    app.config['STEAM_API_KEY'] = os.environ.get('STEAM_API_KEY', '')
 
     # SSE: disable connection pooling timeout issues under high thread counts.
     # pool_size=0 → NullPool when using SQLite; for Postgres keep default but

--- a/website/models.py
+++ b/website/models.py
@@ -74,6 +74,7 @@ class Participant(db.Model):
         db.String(32), unique=True,
         default=lambda: secrets.token_hex(16)
     )
+    steam_id = db.Column(db.String(64), nullable=True)
 
     def __repr__(self):
         """Return string representation."""

--- a/website/static/css/calendar.css
+++ b/website/static/css/calendar.css
@@ -222,3 +222,19 @@
 .fc .fc-daygrid-day {
     background: #12151e;
 }
+
+.genre-pill {
+    font-size: 12px;
+    padding: 3px 10px;
+    border-radius: 20px;
+    border: 1px solid #3a3a55;
+    background: #1e1e2e;
+    color: #9ca3af;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+.genre-pill.active {
+    background: #7c3aed;
+    color: #fff;
+    border-color: #7c3aed;
+}

--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -820,6 +820,11 @@ hr {
     flex: 1;
 }
 
+.vote-field--wide {
+    max-width: none;
+    width: 100%;
+}
+
 /* Game tally grid */
 .game-tally-grid {
     display: flex;

--- a/website/steam.py
+++ b/website/steam.py
@@ -1,0 +1,78 @@
+import requests
+
+STEAM_API_BASE = "https://api.steampowered.com"
+
+def resolve_steam_id(steam_input: str, api_key: str) -> str | None:
+    """
+    Accepts a Steam64 ID, a full profile URL, or a vanity name.
+    Returns the Steam64 ID string, or None on failure.
+    """
+    steam_input = steam_input.strip().rstrip("/")
+
+    # Already a numeric Steam64 ID
+    if steam_input.isdigit() and len(steam_input) == 17:
+        return steam_input
+
+    # Extract vanity name from URL
+    # e.g. https://steamcommunity.com/id/somename  or  https://steamcommunity.com/profiles/76561198...
+    if "steamcommunity.com/profiles/" in steam_input:
+        candidate = steam_input.split("steamcommunity.com/profiles/")[-1].strip("/")
+        if candidate.isdigit():
+            return candidate
+
+    if "steamcommunity.com/id/" in steam_input:
+        vanity = steam_input.split("steamcommunity.com/id/")[-1].strip("/")
+    else:
+        vanity = steam_input  # treat raw input as vanity name
+
+    resp = requests.get(
+        f"{STEAM_API_BASE}/ISteamUser/ResolveVanityURL/v1/",
+        params={"key": api_key, "vanityurl": vanity},
+        timeout=10,
+    )
+    data = resp.json().get("response", {})
+    if data.get("success") == 1:
+        return data["steamid"]
+    return None
+
+
+def get_steam_games(steam_id: str, api_key: str, top_n: int = 5) -> dict:
+    """
+    Returns:
+      {
+        "recent_games": ["Game A", "Game B", ...],  # played in last 2 weeks
+        "top_games":    ["Game A", "Game B", ...],  # top N by all-time playtime
+        "all_names":    {"game a", "game b", ...}   # full owned set (lowercase)
+      }
+    """
+    # Recently played (last 2 weeks) — strongest signal
+    recent_resp = requests.get(
+        f"{STEAM_API_BASE}/IPlayerService/GetRecentlyPlayedGames/v1/",
+        params={"key": api_key, "steamid": steam_id, "count": 10},
+        timeout=15,
+    )
+    recent_resp.raise_for_status()
+    recent_games = [
+        g["name"] for g in recent_resp.json().get("response", {}).get("games", [])
+        if "name" in g
+    ]
+
+    # Full library — for ownership matching
+    owned_resp = requests.get(
+        f"{STEAM_API_BASE}/IPlayerService/GetOwnedGames/v1/",
+        params={
+            "key": api_key,
+            "steamid": steam_id,
+            "include_appinfo": True,
+            "include_played_free_games": True,
+        },
+        timeout=15,
+    )
+    owned_resp.raise_for_status()
+    owned = owned_resp.json().get("response", {}).get("games", [])
+    owned.sort(key=lambda g: g.get("playtime_forever", 0), reverse=True)
+
+    top_games = [g["name"] for g in owned[:top_n] if "name" in g]
+    all_names = {g["name"].lower() for g in owned if "name" in g}
+
+    return {"recent_games": recent_games, "top_games": top_games, "all_names": all_names}

--- a/website/templates/session.html
+++ b/website/templates/session.html
@@ -66,7 +66,7 @@
             <p class="section-hint">Drag to mark your availability — you can save it by joining below.</p>
         {% endif %}
 
-        <div id="group-calendar" style="min-height: 450px; width: 100%;"></div>
+        <div id="group-calendar" style="min-height: 600px; width: 100%;"></div>
 
         {% if not token %}
             <div class="join-nudge mt-3">
@@ -141,6 +141,88 @@
                 <div class="game-tally-grid d-flex flex-wrap justify-content-center gap-3" id="game-tally-list"></div>
                 <p class="section-hint text-center" id="no-votes-msg">No votes yet — suggest a game above.</p>
             {% endif %}
+            {# ── STEAM LINK ── #}
+            <div class="mt-4" id="steam-link-section">
+                <div style="border:1px solid rgba(123,47,247,0.35); border-radius:10px; background:rgba(123,47,247,0.07); padding:1rem 1.25rem; max-width:560px; margin:0 auto;">
+                    <div class="d-flex align-items-center justify-content-center gap-2 mb-1">
+                        <span style="font-size:1rem;">🎮</span>
+                        <span class="fw-semibold text-white" style="font-size:0.95rem;">Steam Library</span>
+                        {% if participant.steam_id %}
+                            <span id="steam-linked-badge" style="font-size:0.75rem; background:rgba(34,197,94,0.15); color:#22c55e; border:1px solid rgba(34,197,94,0.3); border-radius:20px; padding:1px 8px;" class="ms-1">Linked</span>
+                        {% else %}
+                            <span id="steam-linked-badge" style="display:none; font-size:0.75rem; background:rgba(34,197,94,0.15); color:#22c55e; border:1px solid rgba(34,197,94,0.3); border-radius:20px; padding:1px 8px;" class="ms-1">Linked</span>
+                        {% endif %}
+                    </div>
+                    <p class="text-white-50 mb-2" style="font-size:0.78rem;">Link your profile so the AI can factor in your played games.</p>
+                    {# Shared input row used by both link and change flows #}
+                    <div id="steam-input-row" style="display:{% if not participant.steam_id %}block{% else %}none{% endif %}; margin-bottom:0.5rem;">
+                        <div class="d-flex gap-2 align-items-center" style="max-width:440px; margin:0 auto;">
+                            <input type="text" id="steam-input"
+                                placeholder="{% if participant.steam_id %}e.g. https://steamcommunity.com/id/yourname{% else %}steamcommunity.com/id/yourname  or  Steam64 ID{% endif %}"
+                                class="form-control" style="font-size:0.85rem;">
+                            {% if participant.steam_id %}
+                                <button class="btn btn-outline-secondary btn-sm" onclick="saveSteam()" style="white-space:nowrap;">Save</button>
+                                <button class="btn btn-link btn-sm text-white-50 p-0" onclick="hideSteamInput()" style="white-space:nowrap;">Cancel</button>
+                            {% else %}
+                                <button class="btn btn-sm" onclick="saveSteam()"
+                                        style="white-space:nowrap; background:#5865f2; color:#fff; border:none;">
+                                    🔗 Link
+                                </button>
+                            {% endif %}
+                        </div>
+                        {% if not participant.steam_id %}
+                            <p class="mt-1 mb-0 text-white-50 text-center" style="font-size:0.72rem;">Library must be set to public on Steam</p>
+                        {% endif %}
+                    </div>
+
+                    {% if participant.steam_id %}
+                        <p class="text-white-50 mb-2 text-center" style="font-size:0.78rem;">Your Steam library is being used for game recommendations.</p>
+                        <div id="steam-linked-controls" class="d-flex gap-3 align-items-center justify-content-center">
+                            <button class="btn btn-link btn-sm p-0" style="color:#a78bfa; font-size:0.8rem;" onclick="showSteamInput()">Change →</button>
+                            <button class="btn btn-link btn-sm p-0" style="color:#ef4444; font-size:0.8rem;" onclick="disconnectSteam()">Disconnect</button>
+                        </div>
+                    {% else %}
+                        <div id="steam-linked-controls" style="display:none;" class="d-flex gap-3 align-items-center justify-content-center">
+                            <button class="btn btn-link btn-sm p-0" style="color:#a78bfa; font-size:0.8rem;" onclick="showSteamInput()">Change →</button>
+                            <button class="btn btn-link btn-sm p-0" style="color:#ef4444; font-size:0.8rem;" onclick="disconnectSteam()">Disconnect</button>
+                        </div>
+                    {% endif %}
+                    <p id="steam-status" class="small mt-2 mb-0" style="display:none;"></p>
+                    {% set linked = [] %}
+                    {% for p in session.participants %}
+                        {% if p.steam_id %}
+                            {% set _ = linked.append(p.name ~ ' → steamcommunity.com/profiles/' ~ p.steam_id) %}
+                        {% endif %}
+                    {% endfor %}
+                    {% if linked %}
+                        <p class="text-white-50 mt-2 mb-0 text-center" style="font-size:0.72rem;">
+                            🔗 Steam linked: {{ linked | join(', ') }}
+                        </p>
+                    {% endif %}
+                </div>
+            </div>
+            {# ── GAME RECOMMENDATION CARD ── #}
+            {% if is_host %}
+            <div id="game-recommendation-card" style="display:none;" class="mt-4 p-3"
+                style="background:rgba(123,47,247,0.08);border:1px solid rgba(123,47,247,0.3);border-radius:10px;">
+                <p class="small text-white-50 mb-3 text-center">✨ AI Recommendation</p>
+
+                {# Top pick #}
+                <div class="d-flex flex-column align-items-center mb-4" id="rec-top">
+                    <img id="rec-top-img" src="" alt="" class="game-cover-img mb-2"
+                        style="width:480px; height:320px; object-fit:cover; border-radius:8px; display:none;">
+                    <p class="fw-bold text-white mb-1 text-center" id="rec-game-name" style="font-size:1.1rem;"></p>
+                    <p class="small mb-2 text-center" style="color:#b89ff7" id="rec-game-reason"></p>
+                    <form action="{{ url_for('main.set_game', session_hash=session.hash_id) }}?token={{ token }}" method="POST">
+                        <input type="hidden" name="game_name" id="rec-set-game-input">
+                        <button type="submit" class="btn btn-outline-success btn-sm">Set as tonight's game ✓</button>
+                    </form>
+                </div>
+
+                {# Alternatives #}
+                <div id="rec-alternatives" class="d-flex flex-wrap justify-content-center gap-3"></div>
+            </div>
+            {% endif %}
         {% else %}
            {# Non-member view: teaser only, no vote input #}
             <h4 class="section-title">What to play?</h4>
@@ -186,7 +268,7 @@
                     {% endfor %}
                 </div>
             {% else %}
-                <div class="game-tally-grid d-flex flex-wrap justify-content-center gap-3" id="game-tally-list">
+                <div class="game-tally-grid d-flex flex-wrap justify-content-center gap-3" id="game-tally-list"></div>
                 <p class="section-hint text-center" id="no-votes-msg">No votes yet.</p>
             {% endif %}
         {% endif %}
@@ -215,6 +297,11 @@
                         <label class="form-label text-white small mb-1">Email</label>
                         <input type="email" name="email" placeholder="For your Personal Links!" required
                                class="form-control join-input">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label text-white small mb-1">Games You Like <span class="text-white-50">(optional)</span></label>
+                        <input type="text" name="game_interests" placeholder="e.g. Valorant, Stardew Valley, Among Us"
+                            class="form-control join-input">
                     </div>
                 </div>
 
@@ -256,7 +343,7 @@
                     value="{{ url_for('main.view_session', session_hash=session.hash_id, token=participant.token, _external=True) }}">
                 <button class="btn btn-outline-secondary btn-sm" onclick="copyLink(this)">Copy</button>
             </div>
-            <small class="text-white-50">Use this link to update your availability later.</small>
+            <small class="text-white-50">Use this link to update your availability later. One has already been emailed to you.</small>
         </div>
     </div>
     {% endif %}
@@ -280,6 +367,96 @@
                     <input type="datetime-local" name="manual_time" required class="form-control join-input">
                     <button type="submit" class="btn btn-success">Set Time</button>
                 </form>
+            </div>
+            <div class="host-control-block" style="grid-column: 1 / -1;">
+                <p class="fw-bold text-white mb-1">Game Recommendation</p>
+                <p class="small text-white-50 mb-3">AI picks the best game for tonight based on your squad's votes, Steam libraries, and preferences.</p>
+
+                <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem; margin-bottom:1.25rem;">
+
+                    <div>
+                        <p style="font-size:11px; font-weight:500; color:#6b7280; text-transform:uppercase; letter-spacing:0.06em; margin:0 0 8px;">Prioritize by</p>
+                        <div style="display:flex; flex-direction:column; gap:6px;">
+                            <label style="display:flex; align-items:center; gap:8px; font-size:13px; color:#d1d5db; cursor:pointer;">
+                                <input type="checkbox" id="opt-votes" checked> Votes
+                            </label>
+                            <label style="display:flex; align-items:center; gap:8px; font-size:13px; color:#d1d5db; cursor:pointer;">
+                                <input type="checkbox" id="opt-recent"> Recent Steam play
+                            </label>
+                            <label style="display:flex; align-items:center; gap:8px; font-size:13px; color:#d1d5db; cursor:pointer;">
+                                <input type="checkbox" id="opt-ownership"> Ownership overlap
+                            </label>
+                        </div>
+                    </div>
+
+                    <div>
+                        <p style="font-size:11px; font-weight:500; color:#6b7280; text-transform:uppercase; letter-spacing:0.06em; margin:0 0 8px;">Ownership filter</p>
+                        <div style="display:flex; flex-direction:column; gap:6px;">
+                            <label style="display:flex; align-items:center; gap:8px; font-size:13px; color:#d1d5db; cursor:pointer;">
+                                <input type="radio" name="ownership-filter" value="any" checked> Any game
+                            </label>
+                            <label style="display:flex; align-items:center; gap:8px; font-size:13px; color:#d1d5db; cursor:pointer;">
+                                <input type="radio" name="ownership-filter" value="some"> At least some own it
+                            </label>
+                            <label style="display:flex; align-items:center; gap:8px; font-size:13px; color:#d1d5db; cursor:pointer;">
+                                <input type="radio" name="ownership-filter" value="all"> Everyone owns it
+                            </label>
+                            <label style="display:flex; align-items:center; gap:8px; font-size:13px; color:#d1d5db; cursor:pointer;">
+                                <input type="radio" name="ownership-filter" value="none"> Nobody owns it yet
+                            </label>
+                        </div>
+                    </div>
+
+                    <div>
+                        <p style="font-size:11px; font-weight:500; color:#6b7280; text-transform:uppercase; letter-spacing:0.06em; margin:0 0 8px;">Genre</p>
+                        <div style="display:flex; flex-wrap:wrap; gap:6px;" id="genre-pills">
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill active" data-genre="any">Any</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="FPS">FPS</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Strategy">Strategy</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="RPG">RPG</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Battle Royale">Battle Royale</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Survival">Survival</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Casual">Casual</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Co-op">Co-op</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Competitive">Competitive</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Party">Party</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Roguelike">Roguelike</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="MOBA">MOBA</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="MMO">MMO</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Racing">Racing</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Sports">Sports</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Horror">Horror</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Tower Defense">Tower Defense</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Sandbox">Sandbox</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Fighting">Fighting</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Platformer">Platformer</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Card Game">Card Game</button>
+                            <button type="button" onclick="toggleGenre(this)" class="genre-pill" data-genre="Puzzle">Puzzle</button>
+                        </div>
+                    </div>
+
+                    <div>
+                        <p style="font-size:11px; font-weight:500; color:#6b7280; text-transform:uppercase; letter-spacing:0.06em; margin:0 0 8px;">Other</p>
+                        <div style="display:flex; flex-direction:column; gap:6px;">
+                            <label style="display:flex; align-items:center; gap:8px; font-size:13px; color:#d1d5db; cursor:pointer;">
+                                <input type="checkbox" id="opt-ignore-votes"> Ignore votes entirely
+                            </label>
+                            <label style="display:flex; align-items:center; gap:8px; font-size:13px; color:#d1d5db; cursor:pointer;">
+                                <input type="checkbox" id="opt-free"> Free-to-play only
+                            </label>
+                            <label style="display:flex; align-items:center; gap:8px; font-size:13px; color:#d1d5db; cursor:pointer;">
+                                <input type="checkbox" id="opt-new"> Suggest something new
+                            </label>
+                            <label style="display:flex; align-items:center; gap:8px; font-size:13px; color:#d1d5db; cursor:pointer;">
+                                <input type="checkbox" id="opt-coop"> Everyone on the same team
+                            </label>
+                        </div>
+                    </div>
+
+                </div>
+
+                <button class="btn btn-primary d-block mx-auto" style="width:100%"
+                        onclick="getGameRecommendation()">✨ Recommend a Game</button>
             </div>
         </div>
     </div>
@@ -321,6 +498,221 @@ function submitConfirm(token, status) {
     fetch("{{ url_for('main.confirm', session_id=session.id, token='TOKEN') }}".replace('TOKEN', token), {
         method: 'POST', body: fd
     });
+}
+</script>
+
+<script>
+function toggleGenre(btn) {
+    const isAny = btn.dataset.genre === 'any';
+    const pills = document.querySelectorAll('.genre-pill');
+    if (isAny) {
+        pills.forEach(p => p.classList.remove('active'));
+        btn.classList.add('active');
+        return;
+    }
+    // Deactivate "Any"
+    document.querySelector('.genre-pill[data-genre="any"]').classList.remove('active');
+    btn.classList.toggle('active');
+    // If nothing selected, re-activate Any
+    const anyActive = [...pills].some(p => p.classList.contains('active') && p.dataset.genre !== 'any');
+    if (!anyActive) {
+        document.querySelector('.genre-pill[data-genre="any"]').classList.add('active');
+    }
+}
+
+document.getElementById('opt-ignore-votes').addEventListener('change', function() {
+    if (this.checked) document.getElementById('opt-votes').checked = false;
+});
+document.getElementById('opt-votes').addEventListener('change', function() {
+    if (this.checked) document.getElementById('opt-ignore-votes').checked = false;
+});
+
+function getGameRecommendation() {
+    const btn = event.target;
+    btn.disabled = true;
+    btn.textContent = 'Thinking...';
+
+    const ownershipFilter = document.querySelector('input[name="ownership-filter"]:checked').value;
+
+    const selectedGenres = [...document.querySelectorAll('.genre-pill.active')]
+        .map(p => p.dataset.genre)
+        .filter(g => g !== 'any');
+
+    const fd = new FormData();
+    fd.append('token', '{{ token }}');
+    fd.append('prioritize_votes',     document.getElementById('opt-votes').checked     ? '1' : '0');
+    fd.append('prioritize_recent',    document.getElementById('opt-recent').checked    ? '1' : '0');
+    fd.append('prioritize_ownership', document.getElementById('opt-ownership').checked ? '1' : '0');
+    fd.append('ignore_votes',         document.getElementById('opt-ignore-votes').checked ? '1' : '0');
+    fd.append('free_to_play',         document.getElementById('opt-free').checked      ? '1' : '0');
+    fd.append('suggest_new',          document.getElementById('opt-new').checked       ? '1' : '0');
+    fd.append('ownership_filter', ownershipFilter);
+    fd.append('genres', selectedGenres.join(','));
+    fd.append('coop_only', document.getElementById('opt-coop').checked ? '1' : '0');
+
+    fetch('/session/{{ session.hash_id }}/recommend_game', { method: 'POST', body: fd })
+        .then(r => r.json())
+        .then(function(data) {
+            btn.disabled = false;
+            btn.textContent = '✨ Recommend a Game';
+            if (!data.ok) {
+                alert(data.error || 'Could not get recommendation.');
+                return;
+            }
+
+            const picks = data.picks;
+            const top = picks[0];
+
+            document.getElementById('rec-game-name').textContent = top.game;
+            document.getElementById('rec-game-reason').textContent = top.reason;
+            document.getElementById('rec-set-game-input').value = top.game;
+
+            if (window.rawgApiKey) {
+                fetch(`https://api.rawg.io/api/games?key=${window.rawgApiKey}&search=${encodeURIComponent(top.game)}&page_size=1`)
+                    .then(r => r.json())
+                    .then(d => {
+                        const img = document.getElementById('rec-top-img');
+                        if (d.results && d.results[0] && d.results[0].background_image) {
+                            img.src = d.results[0].background_image;
+                            img.style.display = 'block';
+                        }
+                    }).catch(() => {});
+            }
+
+            const altContainer = document.getElementById('rec-alternatives');
+            altContainer.innerHTML = '';
+            picks.slice(1).forEach(function(pick, i) {
+                const card = document.createElement('div');
+                card.style.cssText = 'background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.1);border-radius:8px;padding:0.6rem 0.8rem;max-width:180px;text-align:center;';
+                card.innerHTML = `
+                    <p style="font-size:0.7rem;color:#9ca3af;margin-bottom:6px;">#${i+2}</p>
+                    <img data-game="${pick.game}" src="" alt="${pick.game}"
+                        style="width:100%;height:90px;object-fit:cover;border-radius:6px;display:none;margin-bottom:6px;">
+                    <p style="font-size:0.85rem;font-weight:600;color:#fff;margin-bottom:4px;">${pick.game}</p>
+                    <p style="font-size:0.72rem;color:#b89ff7;margin-bottom:6px;">${pick.reason}</p>
+                    <form method="POST" action="{{ url_for('main.set_game', session_hash=session.hash_id) }}?token={{ token }}">
+                        <input type="hidden" name="game_name" value="${pick.game}">
+                        <button type="submit" class="btn btn-outline-secondary btn-sm" style="font-size:0.7rem;">Set ✓</button>
+                    </form>`;
+                altContainer.appendChild(card);
+
+                // Fetch cover independently per card
+                if (window.rawgApiKey) {
+                    fetch(`https://api.rawg.io/api/games?key=${window.rawgApiKey}&search=${encodeURIComponent(pick.game)}&page_size=1`)
+                        .then(r => r.json())
+                        .then(d => {
+                            const img = card.querySelector('img');
+                            if (d.results && d.results[0] && d.results[0].background_image) {
+                                img.src = d.results[0].background_image;
+                                img.style.display = 'block';
+                            }
+                        }).catch(() => {});
+                }
+            });
+
+            document.getElementById('game-recommendation-card').style.display = 'block';
+            document.getElementById('game-recommendation-card').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        })
+        .catch(function() {
+            btn.disabled = false;
+            btn.textContent = '✨ Recommend a Game';
+        });
+}
+</script>
+
+<script>
+document.getElementById('opt-ignore-votes').addEventListener('change', function() {
+    if (this.checked) document.getElementById('opt-votes').checked = false;
+});
+document.getElementById('opt-votes').addEventListener('change', function() {
+    if (this.checked) document.getElementById('opt-ignore-votes').checked = false;
+});
+</script>
+
+<script>
+function showSteamInput() {
+    const row = document.getElementById('steam-input-row');
+    const controls = document.getElementById('steam-linked-controls');
+    if (row) row.style.display = 'block';
+    if (controls) controls.style.display = 'none';
+}
+function hideSteamInput() {
+    const row = document.getElementById('steam-input-row');
+    const controls = document.getElementById('steam-linked-controls');
+    if (row) row.style.display = 'none';
+    if (controls) controls.style.display = 'flex';
+    const input = document.getElementById('steam-input');
+    if (input) input.value = '';
+}
+
+function saveSteam() {
+    const input = document.getElementById('steam-input');
+    if (!input) return;
+    const status = document.getElementById('steam-status');
+    const val = input.value.trim();
+    if (!val) return;
+
+    status.style.display = 'block';
+    status.style.color = '#b89ff7';
+    status.textContent = 'Linking…';
+
+    const fd = new FormData();
+    fd.append('token', '{{ token }}');
+    fd.append('steam_input', val);
+
+    fetch('/session/{{ session.hash_id }}/set_steam', { method: 'POST', body: fd })
+        .then(r => r.json())
+        .then(data => {
+            if (data.ok) {
+                status.style.color = '#22c55e';
+                status.textContent = '✓ Linked! Your library will be used in the next recommendation.';
+                input.value = '';
+                hideSteamInput();
+                // Update badge to show Linked
+                const badge = document.getElementById('steam-linked-badge');
+                if (badge) badge.style.display = 'inline';
+                // Show change/disconnect, hide link form
+                const linkForm = document.getElementById('steam-link-form');
+                const linkedControls = document.getElementById('steam-linked-controls');
+                if (linkForm) linkForm.style.display = 'none';
+                if (linkedControls) linkedControls.style.display = 'flex';
+            } else {
+                status.style.color = '#ef4444';
+                status.textContent = '✗ ' + (data.error || 'Could not link Steam.');
+            }
+        })
+        .catch(() => {
+            status.style.color = '#ef4444';
+            status.textContent = '✗ Network error. Try again.';
+        });
+}
+
+function disconnectSteam() {
+    if (!confirm('Remove your Steam profile from this session?')) return;
+    const status = document.getElementById('steam-status');
+    const fd = new FormData();
+    fd.append('token', '{{ token }}');
+    fd.append('steam_input', '');
+    fetch('/session/{{ session.hash_id }}/set_steam', { method: 'POST', body: fd })
+        .then(r => r.json())
+        .then(data => {
+            if (data.ok) {
+                // Hide linked state, show link form
+                const badge = document.getElementById('steam-linked-badge');
+                const linkedControls = document.getElementById('steam-linked-controls');
+                const linkForm = document.getElementById('steam-link-form');
+                const inputRow = document.getElementById('steam-input-row');
+                if (badge) badge.style.display = 'none';
+                if (linkedControls) linkedControls.style.display = 'none';
+                if (inputRow) inputRow.style.display = 'none';
+                if (linkForm) linkForm.style.display = 'block';
+                status.style.display = 'block';
+                status.style.color = '#b89ff7';
+                status.textContent = 'Steam disconnected.';
+            } else {
+                alert(data.error || 'Could not disconnect.');
+            }
+        });
 }
 </script>
 

--- a/website/views.py
+++ b/website/views.py
@@ -20,6 +20,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from website import db, socketio
 from website.models import Confirmation, Participant, Session, Availability, GameVote, Feedback
 from website.utils import notify_final_time, notify_personal_link, notify_feedback_submitted
+from website.steam import resolve_steam_id, get_steam_games
 
 from gevent import spawn
 
@@ -121,6 +122,7 @@ def _ensure_game_election_schema():
             ("experiment_result", "noticed_first", "VARCHAR(20)"),
             ("experiment_result", "real_use_likelihood", "INTEGER"),
             ("experiment_result", "feedback_text", "TEXT"),
+            ("participant", "game_interests", "TEXT"),
         ]:
             try:
                 conn.execute(text(f"ALTER TABLE {table} ADD COLUMN {col} {typ}"))
@@ -1789,3 +1791,253 @@ def experiment_feedback():
         condition=result.condition,
         result_id=result.id,
     )
+
+@main.route("/session/<session_hash>/recommend_game", methods=["POST"])
+def recommend_game(session_hash):
+    import requests as http_requests
+    import re
+
+    game_session = Session.query.filter_by(hash_id=session_hash).first_or_404()
+    participant_token = request.form.get("token")
+    participant = Participant.query.filter_by(token=participant_token).first_or_404()
+    if participant.id != game_session.host_id:
+        return jsonify({"ok": False, "error": "Unauthorized"}), 403
+
+    prioritize_votes     = request.form.get("prioritize_votes") == "1"
+    prioritize_recent    = request.form.get("prioritize_recent") == "1"
+    prioritize_ownership = request.form.get("prioritize_ownership") == "1"
+    ignore_votes         = request.form.get("ignore_votes") == "1"
+    free_to_play         = request.form.get("free_to_play") == "1"
+    suggest_new          = request.form.get("suggest_new") == "1"
+    ownership_filter     = request.form.get("ownership_filter", "any")
+    genres_raw           = request.form.get("genres", "").strip()
+    selected_genres      = [g.strip() for g in genres_raw.split(",") if g.strip()]
+    coop_only            = request.form.get("coop_only") == "1"
+
+    squad_size = len(game_session.participants)
+    votes = GameVote.query.filter_by(session_id=game_session.id).all()
+    voted_game_names = [(v.game_name or "").strip() for v in votes if (v.game_name or "").strip()]
+
+    tally = {}
+    for key in voted_game_names:
+        tally[key] = tally.get(key, 0) + 1
+
+    steam_api_key = current_app.config.get("STEAM_API_KEY", "")
+    interest_lines = []
+    ownership_notes = []
+    recent_notes = []
+    all_owned_sets = {}  # {participant_name: set of lowercase game names}
+
+    for p in game_session.participants:
+        parts = []
+        if getattr(p, "game_interests", None):
+            parts.append(f"stated interests: {p.game_interests}")
+
+        if getattr(p, "steam_id", None) and steam_api_key:
+            try:
+                steam_data = get_steam_games(p.steam_id, steam_api_key, top_n=5)
+                all_owned_sets[p.name] = steam_data["all_names"]
+
+                if steam_data["recent_games"]:
+                    recent_notes.append(f"- {p.name} recently played: {', '.join(steam_data['recent_games'])}")
+                elif steam_data["top_games"]:
+                    recent_notes.append(f"- {p.name} top games: {', '.join(steam_data['top_games'])}")
+
+                owned_voted = [g for g in tally if g.lower() in steam_data["all_names"]]
+                if owned_voted:
+                    ownership_notes.append(f"- {p.name} owns: {', '.join(owned_voted)}")
+            except Exception:
+                pass
+
+        if parts:
+            interest_lines.append(f"- {p.name}: {'; '.join(parts)}")
+
+    # Build ownership constraint instruction
+    ownership_instructions = {
+        "any":  "No ownership restriction — recommend any multiplayer game.",
+        "some": "Only recommend games that at least one squad member already owns.",
+        "all":  "Only recommend games that EVERY squad member already owns.",
+        "none": "Only recommend games that NOBODY in the squad owns yet — something entirely new to buy.",
+    }.get(ownership_filter, "No ownership restriction.")
+
+    # Build weighting instructions
+    weight_instructions = []
+    if ignore_votes:
+        weight_instructions.append("IGNORE vote counts entirely.")
+    elif prioritize_votes:
+        weight_instructions.append("Give strong weight to games with the most votes.")
+    if prioritize_recent:
+        weight_instructions.append("Give strong weight to games squad members played recently.")
+    if prioritize_ownership:
+        weight_instructions.append("Strongly prefer games more squad members already own.")
+    if not weight_instructions:
+        weight_instructions.append("Balance votes, recent play, ownership, and stated interests equally.")
+
+    # Genre constraint
+    genre_instruction = ""
+    if selected_genres:
+        genre_instruction = f"Only recommend games in these genres: {', '.join(selected_genres)}."
+
+    # Extra constraints
+    extra_instructions = []
+    if free_to_play:
+        extra_instructions.append("Only recommend free-to-play games.")
+    if suggest_new:
+        extra_instructions.append("Suggest games nobody in the squad has played before — avoid anything in their Steam libraries.")
+    if coop_only:
+        extra_instructions.append(
+            "ONLY recommend games where everyone in the squad are on the same team working together — "
+            "no PvP, no opposing teams, strictly cooperative or co-op PvE only. "
+            "Examples: Deep Rock Galactic, Left 4 Dead 2, Phasmophobia, It Takes Two, Valheim. "
+            "Do NOT suggest games like League of Legends, CS2, or any game where players compete against each other. (Unless the squad size is smaller than the teams in the game)"
+        )
+    votes_block = ""
+    if not ignore_votes and tally:
+        votes_block = f"Voted games (name: vote count):\n" + "\n".join(
+            f"- {g}: {c} vote(s)" for g, c in sorted(tally.items(), key=lambda x: -x[1])
+        )
+    elif not ignore_votes:
+        votes_block = "Voted games: None yet"
+
+    DEAD_SERVICE_GAMES = [
+        "MultiVersus",
+        "Anthem",
+        "Hyper Scape",
+        "Babylon's Fall",
+        "Knockout City",
+        "Rumbleverse",
+        "Spellbreak",
+        "The Culling",
+        "Radical Heights",
+        "LawBreakers",
+        "Battleborn",
+        "Evolve",
+        "Paragon",
+        "Diabotical",
+        "Crucible",
+        "Marvel Heroes",
+        "Firefall",
+        "WildStar",
+        "Realm Royale",
+    ]
+
+    DEAD_GAMES_STR = ", ".join(f'"{g}"' for g in DEAD_SERVICE_GAMES)
+
+    num_to_request = 8 if ownership_filter != "any" else 4
+    prompt = f"""You are helping {squad_size} friends pick a multiplayer game to play tonight.
+
+{votes_block}
+
+Steam activity:
+{chr(10).join(recent_notes) or "- None provided"}
+
+Ownership of voted games:
+{chr(10).join(ownership_notes) or "- None"}
+
+Stated interests:
+{chr(10).join(interest_lines) or "- None provided"}
+
+Constraints (treat these as hard rules):
+- NEVER suggest "Spacewar", "Steam Linux Runtime", or any Steam tool/runtime.
+- NEVER suggest games with shut-down or dead servers that are no longer playable online: {DEAD_GAMES_STR}. If you are unsure whether a game's online servers are still active, do not suggest it.
+- {ownership_instructions}
+{f"- {genre_instruction}" if genre_instruction else ""}
+{chr(10).join(f"- {x}" for x in extra_instructions)}
+
+Weighting (soft preferences within the constraints above):
+{chr(10).join(f"- {w}" for w in weight_instructions)}
+
+Recommend exactly {num_to_request} multiplayer games ranked best to worst. Real game titles only.
+Reply with ONLY this JSON and nothing else:
+{{
+  "picks": [
+    {{"game": "Game Name", "reason": "One sentence why."}},
+    {{"game": "Game Name", "reason": "One sentence why."}},
+    {{"game": "Game Name", "reason": "One sentence why."}},
+    {{"game": "Game Name", "reason": "One sentence why."}}
+  ]
+}}"""
+
+    hf_key = current_app.config.get("HUGGINGFACE_API_KEY", "")
+    response = http_requests.post(
+        "https://router.huggingface.co/novita/v3/openai/chat/completions",
+        headers={"Authorization": f"Bearer {hf_key}"},
+        json={
+            "model": "inclusionai/ling-2.6-1t",
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 350 if ownership_filter == "any" else 650,
+        },
+        timeout=30,
+    )
+
+    if response.status_code != 200:
+        return jsonify({"ok": False, "error": f"Model error {response.status_code}: {response.text[:200]}"}), 503
+
+    raw = response.json()
+    text = raw["choices"][0]["message"]["content"].strip()
+
+    match = re.search(r'\{.*\}', text, re.DOTALL)
+    if not match:
+        return jsonify({"ok": False, "error": "Could not parse recommendation."}), 500
+
+    try:
+        result = json.loads(match.group())
+        picks = result["picks"]
+    except (json.JSONDecodeError, KeyError):
+        return jsonify({"ok": False, "error": "Could not parse recommendation."}), 500
+    
+    # Hard ownership filter — applied after AI picks, using real Steam data
+    if ownership_filter != "any" and all_owned_sets:
+        squad_count = len(all_owned_sets)
+
+        def passes_ownership(game_name):
+            name_lower = game_name.lower()
+            owner_count = sum(1 for owned in all_owned_sets.values() if name_lower in owned)
+            if ownership_filter == "all":
+                return owner_count == squad_count
+            elif ownership_filter == "some":
+                return owner_count >= 1
+            elif ownership_filter == "none":
+                return owner_count == 0
+            return True
+
+        filtered_picks = [p for p in picks if passes_ownership(p["game"])]
+
+        if not filtered_picks:
+            return jsonify({
+                "ok": False,
+                "error": f"No recommendations passed the ownership filter ({ownership_filter}). "
+                        f"Try linking more Steam profiles or relaxing the filter."
+            }), 200
+
+        # Take up to 4, but surface however many passed rather than failing
+        picks = filtered_picks[:4]
+
+    return jsonify({"ok": True, "picks": picks})
+
+@main.route("/session/<session_hash>/set_steam", methods=["POST"])
+def set_steam(session_hash):
+    game_session = Session.query.filter_by(hash_id=session_hash).first_or_404()
+    participant_token = request.form.get("token")
+    participant = Participant.query.filter_by(token=participant_token).first_or_404()
+
+    raw_input = (request.form.get("steam_input") or "").strip()
+    if not raw_input:
+        participant.steam_id = None
+        db.session.commit()
+        return jsonify({"ok": True})
+
+    api_key = current_app.config.get("STEAM_API_KEY", "")
+    steam_id = resolve_steam_id(raw_input, api_key)
+    if not steam_id:
+        return jsonify({"ok": False, "error": "Could not resolve that Steam profile. Try your Steam64 ID or full profile URL."}), 400
+
+    # Quick validation — make sure the profile is public/reachable
+    try:
+        get_steam_games(steam_id, api_key, top_n=1)
+    except Exception:
+        return jsonify({"ok": False, "error": "Steam profile found but library is private or unreachable."}), 400
+
+    participant.steam_id = steam_id
+    db.session.commit()
+    return jsonify({"ok": True, "steam_id": steam_id})


### PR DESCRIPTION
Introduce Steam integration and an AI-powered game recommendation UI and tests. Added website/steam.py (resolve_steam_id, get_steam_games), registered STEAM_API_KEY and HUGGINGFACE_API_KEY in app config, and added a nullable steam_id column to Participant. Updated session template and CSS to surface Steam linking, recommendation controls, and related UI tweaks. Expanded tests: new tests/test_steam.py for Steam helpers, extended tests/test_utils.py (personal link cases), and large additions to tests/test_views.py covering experiment flows, feedback, set_steam behavior, and recommend_game scenarios (success, auth, model errors, ownership filtering). Also includes small view changes (website/views.py) to hook these features.